### PR TITLE
[rat-drill]New module: List of rats awaiting drills.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ filename | the name (and absolute path) to the JSON file containing the facts | 
 Scans incoming message that start with ! for keywords specified in the file
 configured and replies with the appropriate response.
 
-# rat-dill.py
+# rat-drill.py
 ## Commands
 Command | Parameters | Explanation
 --- | --- | ---

--- a/README.md
+++ b/README.md
@@ -78,3 +78,22 @@ filename | the name (and absolute path) to the JSON file containing the facts | 
 Scans incoming message that start with ! for keywords specified in the file
 configured and replies with the appropriate response.
 
+# rat-dill.py
+## Commands
+Command | Parameters | Explanation
+--- | --- | ---
+`drill` | | Print out both drill lists.
+ | `-b` | See above
+ | `-r` | Print only the [R]atting drills list.
+ | `-d` / `-p` | Print only the [D]is[P]atch drills list.
+`drilladd` | -r `name` | Add `name` to the [R]atting drills list.
+ | -d `name` / -p `name` | Add `name` to the [D]is[P]atch drills list.
+ | -b `name` | Add `name` to [B]oth the ratting and dispatch drills list.
+`drillrem` | `name` | Remove `name` from both drill lists (if applicable).
+ | | To remove `name` from only 1 list, use `drilladd`
+
+## Config
+Name | Purpose | Example
+--- | --- | ---
+drilllist | The name of the JSON file containing the drill lists | drills.json
+

--- a/sopel-modules/rat-drill.py
+++ b/sopel-modules/rat-drill.py
@@ -1,0 +1,152 @@
+#coding: utf8
+"""
+rat-board.py - Fuel Rats Cases module.
+Copyright 2015, Dimitri "Tyrope" Molenaars <tyrope@tyrope.nl>
+Licensed under the Eiffel Forum License 2.
+
+This module is built on top of the Sopel system.
+http://sopel.chat/
+"""
+
+#Python core imports
+import json
+import os
+
+#Sopel Imports
+from sopel.module import commands
+from sopel.tools import SopelMemory
+
+def setup(bot):
+    if 'ratbot' not in bot.memory:
+        bot.memory['ratbot'] = SopelMemory()
+
+    bot.memory['ratbot']['drilllist'] = os.path.join(
+        bot.config.core.homedir, 'drills.json')
+
+@commands('drill')
+def listDrills(bot, trigger):
+    """Lists all current rats waiting for a drill, and their drill type."""
+
+    #Argument parsing
+    if trigger.group(3) != None:
+        arg = trigger.group(3).lower()
+    else:
+        arg = ''
+
+    if arg == '-r':
+        patchdrills = False
+        ratdrills = True
+    elif arg in ('-p', '-d'):
+        patchdrills = True
+        ratdrills = False
+    else:
+        patchdrills = True
+        ratdrills = True
+
+    # Load the list
+    try:
+        with open(bot.memory['ratbot']['drilllist']) as f:
+            ls = json.load(f)
+    except IOError as e:
+        return bot.say('I can\'t seem to open the list.')
+
+    # Parse the list
+    pdrill = set()
+    rdrill = set()
+    for name, types in ls.items():
+        if types['patchdrill']:
+            pdrill.add(name)
+        if types['ratdrill']:
+            rdrill.add(name)
+
+    # Print the list
+    msg = ''
+    if ratdrills and len(rdrill) > 0:
+        msg += 'Ratting drills: '+', '.join(rdrill)
+        if patchdrills and len(pdrill) > 0:
+            msg += '. '
+
+    if patchdrills and len(pdrill) > 0:
+        msg += 'Dispatch drills: '+', '.join(pdrill)
+
+    if len(msg) == 0:
+        return bot.reply('That list is empty.')
+    else:
+        return bot.reply(msg)
+
+@commands('drilladd')
+def addDrill(bot, trigger):
+    """Adds a rat to the list of awaiting drills.
+    Arguments:
+    -r = [r]atting drill only
+    -d / -p = [d]is[p]atch drill only
+    -b = [b]oth types of drills."""
+
+    #Argument parsing
+    if trigger.group(3) == None:
+        return bot.reply('Missing 2 arguments.')
+
+    if trigger.group(4) == None:
+        return bot.reply('Missing 1 argument.')
+
+    arg = trigger.group(3).lower()
+
+    if arg == '-r':
+        pdrill = False
+        rdrill = True
+    elif arg in ('-p', '-d'):
+        pdrill = True
+        rdrill = False
+    elif arg == '-b':
+        pdrill = True
+        rdrill = True
+    else:
+        return bot.reply('invalid drill type, use -r, -d, -p or -b.')
+
+    # Prepare new rat
+    drill = {trigger.group(4): {'patchdrill':pdrill,'ratdrill':rdrill}}
+
+    # Fetch list
+    try:
+        with open(bot.memory['ratbot']['drilllist']) as f:
+            ls = json.load(f)
+    except IOError:
+        # File doesn't exist.
+        ls = dict()
+
+    # Add rat
+    ls.update(drill)
+
+    with open(bot.memory['ratbot']['drilllist'], 'w') as f:
+        json.dump(ls, f)
+
+    return bot.reply('CMDR %s added to drill list.' % (trigger.group(4),))
+
+
+@commands('drilldel', 'drillrem')
+def removeDrill(bot, trigger):
+    """Removes a rat from the list of awaiting drills.
+    NOTE: to only remove the rat from 1 type, use !drilladd instead"""
+
+    #Argument parsing
+    if trigger.group(3) == None:
+        return bot.reply('I need a rat to remove...')
+    else:
+        CMDR = trigger.group(3)
+
+    # Load list
+    with open(bot.memory['ratbot']['drilllist']) as f:
+        ls = json.load(f)
+
+    # Check if in the list
+    if CMDR not in ls:
+        return bot.reply('CMDR %s not in the drill list.' % (CMDR,))
+
+
+    # Remove from and upload list.
+    del ls[CMDR]
+    with open(bot.memory['ratbot']['drilllist'], 'w') as f:
+        json.dump(ls, f)
+
+    return bot.reply('CMDR %s removed from the list.' % (CMDR,))
+


### PR DESCRIPTION
As requested by Derrybear.

Adds 3 new commands:
`!drilladd` Adds rats to the list, or updates their drilltypes

```
1406.45Z] <~Tyrope> !drilladd
[1406.45Z] <&RatTy> Tyrope: Missing 2 arguments.
[1406.48Z] <~Tyrope> !drilladd Tyrope
[1406.48Z] <&RatTy> Tyrope: Missing 1 argument.
[1408.05Z] <~Tyrope> !drilladd -b Tyrope
[1408.05Z] <&RatTy> Tyrope: CMDR Tyrope added to drill list.
[1411.01Z] <~Tyrope> !drilladd -r Tyrope
[1411.01Z] <&RatTy> Tyrope: CMDR Tyrope added to drill list.
```

`!drillrem` Removes rats from the drilllist

```
[1413.24Z] <~Tyrope> !drillrem TestRat
[1413.24Z] <&RatTy> Tyrope: CMDR TestRat removed from the list.
```

`!drill` Lists all rats awaiting specific drills:

```
[1412.13Z] <~Tyrope> !drill
[1412.13Z] <&RatTy> Tyrope: Ratting drills: Tyrope. Dispatch drills: TestRat
[1413.11Z] <~Tyrope> !drill -r
[1413.11Z] <&RatTy> Tyrope: That list is empty.
[1413.17Z] <~Tyrope> !drill -d
[1413.17Z] <&RatTy> Tyrope: Dispatch drills: TestRat
```
