### PR TITLE
feature / Rat-reddit

### DIFF
--- a/sopel-modules/rat-reddit.py
+++ b/sopel-modules/rat-reddit.py
@@ -1,4 +1,4 @@
-#coding: utf8
+#coding: UTF-8
 """
 rat-reddit.py - Fuel Rat Reddit notification module.
 Copyright 2016, Justin "ZeroSteelfist" Fletchall <justin@fletchall.me>
@@ -12,132 +12,157 @@ import sopel.formatting
 import praw
 import re
 import datetime
+import time
 
-#compare current and past entry titles and times with these
-#TO-DO rewrite this to not use globals and instead pass values between functions
-global redditSubmissionTitle
-redditSubmissionTitle = "No Entries Yet"
-global ratsignalURL
-ratsignalURL = ""
-
-#control the submission iterations
-global currentPlaceInSubmissionList
-currentPlaceInSubmissionList = 1
-
-global numberOfNewCalls
-numberOfNewCalls = 0
-
-global botTalkToggle
-botTalkToggle = False
-
-#how the bot is identified by reddit
-user_agent = ("fuelRatChecker 0.2")
-r = praw.Reddit(user_agent = user_agent)
-
-#change this to pull data from another location
-subreddit = r.get_subreddit("fuelrats")
-
-global automaticNotificationTimer
-automaticNotificationTimer = 60
-
-global redditCheckTimer
-redditCheckTimer = 0.0 #(float(datetime.datetime.utcfromtimestamp(todayStamp)))
-
-global masterTalkToggle
-masterTalkToggle = True
-
-
-#this will run at the module initialization to set the first comparison date
 def setup(bot):
-	for submission in subreddit.get_new(limit =1):
-		global redditCheckTimer
-		global redditSubmissionTitle
-		redditCheckTimer = submission.created_utc
-		lastPostTimestamp = datetime.datetime.fromtimestamp(int(submission.created_utc)).strftime('%Y-%m-%d %H:%M:%S')
-		redditSubmissionTitle = ("No new distress calls since " + lastPostTimestamp)
+	global redditSubmissionTitle
+	redditSubmissionTitle = "No Entries Yet"
+	global ratsignalURL
+	ratsignalURL = ""
+
+	#control the submission iterations
+	global currentPlaceInSubmissionList
+	currentPlaceInSubmissionList = 1
+
+	global numberOfNewCalls
+	numberOfNewCalls = 0
+	global botTalkToggle
+	botTalkToggle = False
+
+	#how the bot is identified by reddit
+	user_agent = ("fuelRatChecker 0.2")
+	global r
+	r = praw.Reddit(user_agent = user_agent)
+
+	#change this to pull data from another location
+	global subreddit
+	subreddit = r.get_subreddit("fuelrats")
+
+	# global automaticNotificationTimer
+	# automaticNotificationTimer = 60
+
+	global redditCheckTimer
+	#today = int(datetime.utcnow())
+	#current_time = datetime.datetime.now(datetime.timezone.utc)
+	#unix_timestamp = current_time.timestamp()
+	#today = datetime.datetime.today()
+	todayStamp = int(time.time())
+	redditCheckTimer =  float(todayStamp) #(float(datetime.datetime.utcfromtimestamp(int(todayStamp)))) #150000 #float(unix_timestamp) - (15000000)
+	#redditCheckTimer = 1500000
+
+	global masterTalkToggle
+	masterTalkToggle = True
+
+	global signalFound
+	signalFound = False
 
 #this handles the reddit links that pass the date check below
 def redditBotFunction(submission):
-	ratsignalString='(Ratsignal)'	# use this for searching the post titles below
-	lastPostTimestamp = datetime.datetime.fromtimestamp(int(submission.created_utc)).strftime('%Y-%m-%d %H:%M:%S')
-	global currentPlaceInSubmissionList
+	""" Declare Globals """
 	global redditSubmissionTitle
 	global botTalkToggle
 	global redditCheckTimer
 	global ratsignalURL
 	global numberOfNewCalls
 	global automaticNotificationTimer
+	global signalFound
+	global currentPlaceInSubmissionList
+	""" -------------- """
+	ratsignalString='(Ratsignal)'	# use this for searching the post titles below
+	lastPostTimestamp = datetime.datetime.fromtimestamp(int(submission.created_utc)).strftime('%Y-%m-%d %H:%M:%S')
 	titleText = submission.selftext
 	regExCheck = re.compile(ratsignalString,re.IGNORECASE|re.DOTALL)
 	checkTitleForRatsignal = regExCheck.search(titleText)
-	currentPlaceInSubmissionList += 1
 	if checkTitleForRatsignal:
 		word1=checkTitleForRatsignal.group(1)
-		#set current place to 6 so it will not overwrite the valid distress call
-		currentPlaceInSubmissionList = 6			    	
 		redditCheckTimer = (float(submission.created_utc))
 		redditSubmissionTitle = submission.title
 		ratsignalURL = submission.url
 		botTalkToggle = True
 		numberOfNewCalls += 1
+		currentPlaceInSubmissionList = 99
 		#this will make the next post cycle wait 5 minutes.
-		automaticNotificationTimer = 300
-
+		#automaticNotificationTimer = 300
+		signalFound = True
+		print ("option one" + redditSubmissionTitle)
 		#automaticNotificationTimer += 60 #add one minute to interval per Ratsignal
 		#implement lastcall log
-	elif (currentPlaceInSubmissionList == 5):
+	elif (signalFound == False):
 		redditSubmissionTitle = ("No new distress calls since " + lastPostTimestamp)
 		botTalkToggle = False
-		automaticNotificationTimer = 120
+		#automaticNotificationTimer = 120
+		print ("option two")
+		if (currentPlaceInSubmissionList >=9):
+			#redditCheckTimer = (float(submission.created_utc))
+			print ("option two plus")
+		#redditCheckTimer = (float(submission.created_utc))
+	elif (signalFound == True):
+		signalFound = True
+		print ("option three")
 
 #limit is 2 per second or 30 per minute.
 #can match it to the post frequency, minus a bit to let it run first. Too fast and it will collect data without posting it.
-@sopel.module.interval((automaticNotificationTimer - 10))
+@sopel.module.interval((25))
 def reddit_check(bot):
+	""" Declare Globals """
 	global currentPlaceInSubmissionList
 	global numberOfNewCalls
+	global signalFound
+	global redditCheckTimer
+	global ratsignalURL
+	""" ----------- """
+	signalFound = False
 	numberOfNewCalls = 0
+	# print (redditCheckTimer)
+	# print ("-+-+-+-+-+-+-+-+")
 	currentPlaceInSubmissionList = 1
-	for submission in subreddit.get_new(limit = 5):
-		global redditCheckTimer
-		global ratsignalURL
+	for submission in subreddit.get_new(limit = 10):
+		if (((submission.created_utc) < (redditCheckTimer))): #or (currentPlaceInSubmissionList >= 9)):
+			runItem = False
+		elif (currentPlaceInSubmissionList <= 9):
+			runItem = True
+		print (str(runItem) + "\n")
 		#easily compare dates using these two lines
-		# print submission.created_utc
-		print redditCheckTimer
-		if float(submission.created_utc) <= float(redditCheckTimer):
-			if (currentPlaceInSubmissionList == 5):
-				ratsignalURL = ""
-			#print "Item Skipped"
-			#print currentPlaceInSubmissionList
+		# print submission.created_utcint
+		if ((runItem == False)): # and (float(redditCheckTimer) < (float(submission.created_utc)))):
+			print (str(currentPlaceInSubmissionList) + " SKIPPED ")
 			currentPlaceInSubmissionList += 1
-			break
-		else:
-			#print "Item Run"
+		elif ((runItem == True) and (submission.created_utc > redditCheckTimer)):
+			print ("Item Run")
+			print (str(currentPlaceInSubmissionList) + " Run")
+			currentPlaceInSubmissionList += 1 
 			redditBotFunction(submission)
 
 #this offers the submission title on demand			
 #save the last valid call for reference. offer a url too?
+#sleeps are to keep from getting kicked - limit is 3 lines per 5 seconds
 @sopel.module.commands('reddit')
 def check_reddit(bot, trigger):
 	lastPostTimestamp = datetime.datetime.fromtimestamp(int(redditCheckTimer)).strftime('%Y-%m-%d %H:%M:%S')
 	bot.msg("#rattest", redditSubmissionTitle)
-	bot.msg("#rattest", ratsignalURL)
-	if (numberOfNewCalls > 1):
-		bot.msg("#rattest", "There are currently " + str(numberOfNewCalls) + " new calls.")
+	if signalFound == True:
+		bot.msg("#rattest", ratsignalURL)
+		if (numberOfNewCalls > 1):
+			bot.msg("#rattest", "There are currently " + str(numberOfNewCalls) + " new calls.")
+	time.sleep(5)
 
 #this waits and sends a message to #FuelRats if there is a new Ratsignal on r/fuelrats
-@sopel.module.interval(automaticNotificationTimer)
+@sopel.module.interval(15)
 def repetition_text(bot):
 	if "#rattest" in bot.channels:
 		if botTalkToggle == True:
 			if masterTalkToggle == True:
-				#the system works, and will stay quiet if there is nothing to report. 
+				#print ("the system works, and will stay quiet if there is nothing to report.") 
 				lastPostTimestamp = datetime.datetime.fromtimestamp(int(redditCheckTimer)).strftime('%Y-%m-%d %H:%M:%S')
 				bot.msg("#rattest", redditSubmissionTitle)
-				bot.msg("#rattest", ratsignalURL)
-				if (numberOfNewCalls > 1):
-					bot.msg("#rattest", "There are currently " + str(numberOfNewCalls) + " new calls.")
+				if signalFound == True:
+					bot.msg("#rattest", ratsignalURL)
+					if (numberOfNewCalls > 1):
+						bot.msg("#rattest", "There are currently " + str(numberOfNewCalls) + " new calls.")
+					time.sleep(300) #if there has been a ratsignal, this pauses for 5 mintues to prevent spam.
 
+
+""" These next functions control the masterTalkToggle boolean"""
 @sopel.module.commands('silence')
 def silent_reddit_bot(bot, trigger):
 	global masterTalkToggle
@@ -149,6 +174,7 @@ def silent_reddit_bot(bot, trigger):
 		bot.msg("#rattest", "Reddit bot unmuted.")
 	else:
 		bot.msg("#rattest", "There is a problem with my notification toggle. Contact FR Tech Support.")
+	time.sleep(5)
 
 @sopel.module.commands('silenceon')
 def mute_reddit_bot(bot, trigger):
@@ -158,7 +184,7 @@ def mute_reddit_bot(bot, trigger):
 		masterTalkToggle = False
 	else:
 		bot.msg("#rattest", "Already muted.")
-
+	time.sleep(5)
 
 @sopel.module.commands('silenceoff')
 def unmute_reddit_bot(bot, trigger):
@@ -168,3 +194,4 @@ def unmute_reddit_bot(bot, trigger):
 		bot.msg("#rattest", "Reddit bot unmuted.")
 	else:
 		bot.msg("#rattest", "Already squeaking.")
+	time.sleep(5)

--- a/sopel-modules/rat-reddit.py
+++ b/sopel-modules/rat-reddit.py
@@ -42,10 +42,6 @@ def setup(bot):
 	# automaticNotificationTimer = 60
 
 	global redditCheckTimer
-	#today = int(datetime.utcnow())
-	#current_time = datetime.datetime.now(datetime.timezone.utc)
-	#unix_timestamp = current_time.timestamp()
-	#today = datetime.datetime.today()
 	todayStamp = int(time.time())
 	redditCheckTimer =  float(todayStamp) #(float(datetime.datetime.utcfromtimestamp(int(todayStamp)))) #150000 #float(unix_timestamp) - (15000000)
 	#redditCheckTimer = 1500000
@@ -92,7 +88,7 @@ def redditBotFunction(submission):
 		botTalkToggle = False
 		#automaticNotificationTimer = 120
 		print ("option two")
-		if (currentPlaceInSubmissionList >=9):
+		if (currentPlaceInSubmissionList >=10):
 			#redditCheckTimer = (float(submission.created_utc))
 			print ("option two plus")
 		#redditCheckTimer = (float(submission.created_utc))
@@ -119,7 +115,7 @@ def reddit_check(bot):
 	for submission in subreddit.get_new(limit = 10):
 		if (((submission.created_utc) < (redditCheckTimer))): #or (currentPlaceInSubmissionList >= 9)):
 			runItem = False
-		elif (currentPlaceInSubmissionList <= 9):
+		elif (currentPlaceInSubmissionList <= 10):
 			runItem = True
 		print (str(runItem) + "\n")
 		#easily compare dates using these two lines

--- a/sopel-modules/rat-reddit.py
+++ b/sopel-modules/rat-reddit.py
@@ -1,0 +1,170 @@
+#coding: utf8
+"""
+rat-reddit.py - Fuel Rat Reddit notification module.
+Copyright 2016, Justin "ZeroSteelfist" Fletchall <justin@fletchall.me>
+Licensed under the Eiffel Forum License 2.
+This module is built on top of the Sopel system.
+http://sopel.chat/
+"""
+#import modules
+import sopel.module
+import sopel.formatting
+import praw
+import re
+import datetime
+
+#compare current and past entry titles and times with these
+#TO-DO rewrite this to not use globals and instead pass values between functions
+global redditSubmissionTitle
+redditSubmissionTitle = "No Entries Yet"
+global ratsignalURL
+ratsignalURL = ""
+
+#control the submission iterations
+global currentPlaceInSubmissionList
+currentPlaceInSubmissionList = 1
+
+global numberOfNewCalls
+numberOfNewCalls = 0
+
+global botTalkToggle
+botTalkToggle = False
+
+#how the bot is identified by reddit
+user_agent = ("fuelRatChecker 0.2")
+r = praw.Reddit(user_agent = user_agent)
+
+#change this to pull data from another location
+subreddit = r.get_subreddit("fuelrats")
+
+global automaticNotificationTimer
+automaticNotificationTimer = 60
+
+global redditCheckTimer
+redditCheckTimer = 0.0 #(float(datetime.datetime.utcfromtimestamp(todayStamp)))
+
+global masterTalkToggle
+masterTalkToggle = True
+
+
+#this will run at the module initialization to set the first comparison date
+def setup(bot):
+	for submission in subreddit.get_new(limit =1):
+		global redditCheckTimer
+		global redditSubmissionTitle
+		redditCheckTimer = submission.created_utc
+		lastPostTimestamp = datetime.datetime.fromtimestamp(int(submission.created_utc)).strftime('%Y-%m-%d %H:%M:%S')
+		redditSubmissionTitle = ("No new distress calls since " + lastPostTimestamp)
+
+#this handles the reddit links that pass the date check below
+def redditBotFunction(submission):
+	ratsignalString='(Ratsignal)'	# use this for searching the post titles below
+	lastPostTimestamp = datetime.datetime.fromtimestamp(int(submission.created_utc)).strftime('%Y-%m-%d %H:%M:%S')
+	global currentPlaceInSubmissionList
+	global redditSubmissionTitle
+	global botTalkToggle
+	global redditCheckTimer
+	global ratsignalURL
+	global numberOfNewCalls
+	global automaticNotificationTimer
+	titleText = submission.selftext
+	regExCheck = re.compile(ratsignalString,re.IGNORECASE|re.DOTALL)
+	checkTitleForRatsignal = regExCheck.search(titleText)
+	currentPlaceInSubmissionList += 1
+	if checkTitleForRatsignal:
+		word1=checkTitleForRatsignal.group(1)
+		#set current place to 6 so it will not overwrite the valid distress call
+		currentPlaceInSubmissionList = 6			    	
+		redditCheckTimer = (float(submission.created_utc))
+		redditSubmissionTitle = submission.title
+		ratsignalURL = submission.url
+		botTalkToggle = True
+		numberOfNewCalls += 1
+		#this will make the next post cycle wait 5 minutes.
+		automaticNotificationTimer = 300
+
+		#automaticNotificationTimer += 60 #add one minute to interval per Ratsignal
+		#implement lastcall log
+	elif (currentPlaceInSubmissionList == 5):
+		redditSubmissionTitle = ("No new distress calls since " + lastPostTimestamp)
+		botTalkToggle = False
+		automaticNotificationTimer = 120
+
+#limit is 2 per second or 30 per minute.
+#can match it to the post frequency, minus a bit to let it run first. Too fast and it will collect data without posting it.
+@sopel.module.interval((automaticNotificationTimer - 10))
+def reddit_check(bot):
+	global currentPlaceInSubmissionList
+	global numberOfNewCalls
+	numberOfNewCalls = 0
+	currentPlaceInSubmissionList = 1
+	for submission in subreddit.get_new(limit = 5):
+		global redditCheckTimer
+		global ratsignalURL
+		#easily compare dates using these two lines
+		# print submission.created_utc
+		print redditCheckTimer
+		if float(submission.created_utc) <= float(redditCheckTimer):
+			if (currentPlaceInSubmissionList == 5):
+				ratsignalURL = ""
+			#print "Item Skipped"
+			#print currentPlaceInSubmissionList
+			currentPlaceInSubmissionList += 1
+			break
+		else:
+			#print "Item Run"
+			redditBotFunction(submission)
+
+#this offers the submission title on demand			
+#save the last valid call for reference. offer a url too?
+@sopel.module.commands('reddit')
+def check_reddit(bot, trigger):
+	lastPostTimestamp = datetime.datetime.fromtimestamp(int(redditCheckTimer)).strftime('%Y-%m-%d %H:%M:%S')
+	bot.msg("#rattest", redditSubmissionTitle)
+	bot.msg("#rattest", ratsignalURL)
+	if (numberOfNewCalls > 1):
+		bot.msg("#rattest", "There are currently " + str(numberOfNewCalls) + " new calls.")
+
+#this waits and sends a message to #FuelRats if there is a new Ratsignal on r/fuelrats
+@sopel.module.interval(automaticNotificationTimer)
+def repetition_text(bot):
+	if "#rattest" in bot.channels:
+		if botTalkToggle == True:
+			if masterTalkToggle == True:
+				#the system works, and will stay quiet if there is nothing to report. 
+				lastPostTimestamp = datetime.datetime.fromtimestamp(int(redditCheckTimer)).strftime('%Y-%m-%d %H:%M:%S')
+				bot.msg("#rattest", redditSubmissionTitle)
+				bot.msg("#rattest", ratsignalURL)
+				if (numberOfNewCalls > 1):
+					bot.msg("#rattest", "There are currently " + str(numberOfNewCalls) + " new calls.")
+
+@sopel.module.commands('silence')
+def silent_reddit_bot(bot, trigger):
+	global masterTalkToggle
+	if masterTalkToggle == True:
+		bot.msg("#rattest", "Reddit bot muted.")
+		masterTalkToggle = False
+	elif masterTalkToggle == False:
+		masterTalkToggle = True
+		bot.msg("#rattest", "Reddit bot unmuted.")
+	else:
+		bot.msg("#rattest", "There is a problem with my notification toggle. Contact FR Tech Support.")
+
+@sopel.module.commands('silenceon')
+def mute_reddit_bot(bot, trigger):
+	global masterTalkToggle
+	if masterTalkToggle == True:
+		bot.msg("#rattest", "Reddit bot muted.")
+		masterTalkToggle = False
+	else:
+		bot.msg("#rattest", "Already muted.")
+
+
+@sopel.module.commands('silenceoff')
+def unmute_reddit_bot(bot, trigger):
+	global masterTalkToggle
+	if masterTalkToggle == False:
+		masterTalkToggle = True
+		bot.msg("#rattest", "Reddit bot unmuted.")
+	else:
+		bot.msg("#rattest", "Already squeaking.")

--- a/sopel-modules/rat-reddit.py
+++ b/sopel-modules/rat-reddit.py
@@ -86,7 +86,7 @@ def redditBotFunction(submission):
 
 #limit is 2 per second or 30 per minute.
 #can match it to the post frequency, minus a bit to let it run first. Too fast and it will collect data without posting it.
-@sopel.module.interval((25))
+@sopel.module.interval((60))
 def reddit_check(bot):
 	""" Declare Globals """
 	global currentPlaceInSubmissionList
@@ -129,7 +129,7 @@ def check_reddit(bot, trigger):
 	time.sleep(5)
 
 #this waits and sends a message to #FuelRats if there is a new Ratsignal on r/fuelrats
-@sopel.module.interval(15)
+@sopel.module.interval(65)
 def repetition_text(bot):
 	if "#rattest" in bot.channels:
 		if botTalkToggle == True:

--- a/sopel-modules/rat-reddit.py
+++ b/sopel-modules/rat-reddit.py
@@ -77,24 +77,12 @@ def redditBotFunction(submission):
 		botTalkToggle = True
 		numberOfNewCalls += 1
 		currentPlaceInSubmissionList = 99
-		#this will make the next post cycle wait 5 minutes.
-		#automaticNotificationTimer = 300
 		signalFound = True
-		print ("option one" + redditSubmissionTitle)
-		#automaticNotificationTimer += 60 #add one minute to interval per Ratsignal
-		#implement lastcall log
 	elif (signalFound == False):
 		redditSubmissionTitle = ("No new distress calls since " + lastPostTimestamp)
 		botTalkToggle = False
-		#automaticNotificationTimer = 120
-		print ("option two")
-		if (currentPlaceInSubmissionList >=10):
-			#redditCheckTimer = (float(submission.created_utc))
-			print ("option two plus")
-		#redditCheckTimer = (float(submission.created_utc))
 	elif (signalFound == True):
 		signalFound = True
-		print ("option three")
 
 #limit is 2 per second or 30 per minute.
 #can match it to the post frequency, minus a bit to let it run first. Too fast and it will collect data without posting it.
@@ -109,8 +97,6 @@ def reddit_check(bot):
 	""" ----------- """
 	signalFound = False
 	numberOfNewCalls = 0
-	# print (redditCheckTimer)
-	# print ("-+-+-+-+-+-+-+-+")
 	currentPlaceInSubmissionList = 1
 	for submission in subreddit.get_new(limit = 10):
 		if (((submission.created_utc) < (redditCheckTimer))): #or (currentPlaceInSubmissionList >= 9)):

--- a/sopel.cfg-dist
+++ b/sopel.cfg-dist
@@ -24,7 +24,7 @@ help_prefix = !
 extra = sopel-modules
 
 ## For production/testing
-enable = admin,help,rat-board,rat-facts,rat-search,rat-autocorrect
+enable = admin,help,rat-board,rat-facts,rat-search,rat-autocorrect,rat-reddit
 ## Development use, which may add security risks
 # enable = admin,help,rat-board,rat-facts,rat-search,rat-autocorrect,reload,ipython
 


### PR DESCRIPTION
Pulling into the up to date base this time. Functions like the original module, searching reddit for the distress calls and notifying dispatch. Will sleep 5 minutes after notification of a call to prevent spamming. Notification can be toggled anytime with .silence, silenceon, and silenceoff. Last call time or current call (depending on how recent) can be retrieved with .reddit. These commands should change over to a ! call when loaded with the fuelrat config for sopel.

On launch it pulls the current datetime and will only look for posts newer than that, and updates the date it checks against each time it finds one so as to not repeat notifications. No data added to lists or logs, all the work is still controlled by dispatch, this is for their information only so we may provide timely assistance to those unable to contact us via IRC.
