### PR TITLE
add admin.auto_accept_invite = False

### DIFF
--- a/sopel.cfg-dist
+++ b/sopel.cfg-dist
@@ -33,6 +33,8 @@ logdir = logs
 verbose = verbose
 log_raw = True
 
+[admin]
+auto_accept_invite = False
 
 [ratbot]
 ## Common configuration to all rat modules.


### PR DESCRIPTION
to prevent everyone from being able to invite the bot to a channel.
Make sure to update sopel.cfg's accordingly.
