### PR TITLE
Allow repeated calls to shorten to return the short url

### DIFF
--- a/ratlib/api/http.py
+++ b/ratlib/api/http.py
@@ -224,6 +224,6 @@ class Shortener:
         response.raise_for_status()
         data = response.json()
 
-        if data and data['status'] != 'success':
+        if data and (data['status'] != 'success' and 'shorturl' not in data):
             raise ShortenerError(data['status'], data['message'], data['statusCode'])
         return data


### PR DESCRIPTION
Currently, when a URL is shortened there is no way to re-shorten the same URL. The shortening service returns an error status, even though shortening was technically successful.

This change allows the error handling to spot this condition (error status, but shorturl still included) and avoids raising an exception. This allows the bot to return the original shorturl which is what the user wants.