### PR TITLE
Strip " system" from incoming ratsigs

### DIFF
--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -1344,6 +1344,7 @@ _ratmama_regex = re.compile(r"""
                                          # those cases if it turns out to be a thing, or someone can fix Ratmama too.
     \s+-\s+                              #  -
     System:\s*(?P<system>.*?)            # Match system name
+    (?:\s[sS][yY][sS][tT][eE][mM]|)      # Strip " system" from end, if present (case insensitive)
     \s+-\s+                              #  -
     Platform:\s*(?P<platform>\w+)        # Match platform (currently can't contain spaces)
     \s+-\s+                              #  -

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -1334,7 +1334,7 @@ def cmd_commander(bot, trigger, rescue, commander, db=None):
 _ratmama_regex = re.compile(r"""
     (?x)
     # The above makes whitespace and comments in the pattern ignored.
-    # Saved at https://regex101.com/r/kt3gjH/3
+    # Saved at https://regex101.com/r/jhKtQD/1
     \s*                                  # Handle any possible leading whitespace
     Incoming\s+Client:\s*   # Match "Incoming Client" prefix
     # Wrap the entirety of rest of the pattern in a group to make it easier to echo the entire thing


### PR DESCRIPTION
When a system name ends in " system" it will be ignored by the regexp.