### PR TITLE
Added a sanity check

### DIFF
--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -1194,7 +1194,8 @@ def cmd_assign(bot, trigger, rescue, *rats):
         # Check if id returned is an id, decide for unidentified rats or rats.
         # print("i is " + str(i))
         idstr = str(i['id'])
-        if rat.lower() == rescue.client.lower():  # sanity check
+        print("rescue.data = {}".format(rescue.data['IRCNick']))
+        if rat.lower() == rescue.data['IRCNick'].lower():  # sanity check
             bot.reply("Unable to assign a client to their own case.")
             return
         elif idstr != '0' and idstr != 'None':

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -1194,7 +1194,10 @@ def cmd_assign(bot, trigger, rescue, *rats):
         # Check if id returned is an id, decide for unidentified rats or rats.
         # print("i is " + str(i))
         idstr = str(i['id'])
-        if idstr != '0' and idstr != 'None':
+        if rat.lower() == rescue.client.lower():  # sanity check
+            bot.reply("Unable to assign a client to their own case.")
+            return
+        elif idstr != '0' and idstr != 'None':
             # print('[RatBoard] id was not 0.')
             rescue.rats.update([i['id']])
             ratlist.append(i['name'])

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -1194,7 +1194,6 @@ def cmd_assign(bot, trigger, rescue, *rats):
         # Check if id returned is an id, decide for unidentified rats or rats.
         # print("i is " + str(i))
         idstr = str(i['id'])
-        print("rescue.data = {}".format(rescue.data['IRCNick']))
         if rat.lower() == rescue.data['IRCNick'].lower():  # sanity check
             bot.reply("Unable to assign a client to their own case.")
             return


### PR DESCRIPTION
Added a sanity check to `sopel-modules\rat-board.py`
This sanity check will prevent dispatchers from assigning a client to their own cases.

I myself have done this a few times in error as well as other Dispatches, requiring a pm'ed !unassign afterwards.
The error can produce confusion for clients, as they are told to add themselves to their friends list.

Instead the !assign attempt will fail with a nicely worded error message (please do review)
`"Unable to assign a client to their own case."`