### PR TITLE
Fix createdAt and updatedAt ISO string violation 

### DIFF
--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -690,8 +690,8 @@ def append_quotes(bot, search, lines, autocorrect=True, create=True, detect_plat
 
     json_lines = []
     for line in rv.added_lines:
-        json_lines.append({"message":line, "updatedAt":datetime.datetime.utcnow().isoformat(),
-                           "createdAt":datetime.datetime.utcnow().isoformat(), "author":author, "lastAuthor":author})
+        json_lines.append({"message":line, "updatedAt":datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z'),
+                           "createdAt":datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z'), "author":author, "lastAuthor":author})
     rv.rescue.quotes.extend(json_lines)
     return rv
 
@@ -1128,7 +1128,7 @@ def cmd_sub(bot, trigger, rescue, lineno, line=None):
         rescue.quotes.pop(lineno)
         bot.say("Deleted line {}".format(lineno))
     else:
-        rescue.quotes[lineno] = {"message":line, "updatedAt":datetime.datetime.utcnow().isoformat(),
+        rescue.quotes[lineno] = {"message":line, "updatedAt":datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z'),
                                  "createdAt":rescue.quotes[lineno]["createdAt"],
                                  "author":rescue.quotes[lineno]["author"], "lastAuthor":trigger.nick}
         bot.say("Updated line {}".format(lineno))


### PR DESCRIPTION
An ISO8601 datetime string is expected to have either +00:00 or Z appended to the end to mark it the time is UTC. I opted to replace +00:00 with Z here to stay consistent with other datetime strings provided by the API.