### PR TITLE
Fix MECHA-230

### DIFF
--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -292,7 +292,7 @@ def require_overseer(message='Sorry pal, you\'re not an overseer or higher!'):
         return actual_decorator(message)
     return actual_decorator
 
-def require_dispatch(message=None):
+def require_dispatch(message="Sorry, but you need to be a dispatch or higher to use this command"):
     """Decorate a function to require the triggering user to be a FuelRats dispatch (as in, the currently active dispatch).
     If they are not, `message` will be said if given."""
     def actual_decorator(function):

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -18,6 +18,8 @@ urljoin = ratlib.api.http.urljoin
 savedratids = {}
 savedratnames = {}
 savedclientnames = {}
+# defining this here, so it does not have to be redefined every time a new @require_rat command is made
+msg_not_idented = "Sorry, but you need to be a registered and drilled Rat with an identified IRC nickname to use this command."
 
 def getRatId(bot, ratname, platform=None):
 

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -256,7 +256,7 @@ def require_techrat(message='I am sorry, but this command is restricted for Tech
         return actual_decorator(message)
     return actual_decorator
 
-def require_op(message=None):
+def require_op(message="This command is restricted for Ops and above."):
     """Decorate a function to require the triggering user to be a FuelRats op (as in, an operator.).
     If they are not, `message` will be said if given."""
     def actual_decorator(function):

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -220,7 +220,7 @@ def flushNames():
     savedratnames.clear()
     savedclientnames.clear()
 
-def require_netadmin(message=None):
+def require_netadmin(message="Hey Buddy, you know you need to be an identified NetAdmin to use this command, right?"):
     """Decorate a function to require the triggering user to be a FuelRats netadmin (as in, a highly ranked admin.).
     If they are not, `message` will be said if given."""
     def actual_decorator(function):
@@ -238,7 +238,7 @@ def require_netadmin(message=None):
         return actual_decorator(message)
     return actual_decorator
 
-def require_techrat(message=None):
+def require_techrat(message='I am sorry, but this command is restricted for TechRats and above.'):
     """Decorate a function to require the triggering user to be a FuelRats TechRat (as in, a rat that's part of the RatTech team.).
     If they are not, `message` will be said if given."""
     def actual_decorator(function):

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -18,7 +18,6 @@ urljoin = ratlib.api.http.urljoin
 savedratids = {}
 savedratnames = {}
 savedclientnames = {}
-
 def getRatId(bot, ratname, platform=None):
 
     if ratname in savedratids.keys():
@@ -315,7 +314,7 @@ def require_rat(message="Sorry, but you need to be a registered and drilled Rat 
                         "this command."
 ):
     """Decorate a function to require the triggering user to be a FuelRats rat (as in, registered with the API and drilled).
-    If they are not, `message` will be said if given."""
+    If they are not, `message` will be said."""
     def actual_decorator(function):
         @functools.wraps(function)
         def guarded(bot, trigger, *args, **kwargs):

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -18,7 +18,7 @@ urljoin = ratlib.api.http.urljoin
 savedratids = {}
 savedratnames = {}
 savedclientnames = {}
-# defining this here, so it does not have to be redefined every time a new @require_rat command is made
+
 def getRatId(bot, ratname, platform=None):
 
     if ratname in savedratids.keys():

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -19,8 +19,6 @@ savedratids = {}
 savedratnames = {}
 savedclientnames = {}
 # defining this here, so it does not have to be redefined every time a new @require_rat command is made
-msg_not_idented = "Sorry, but you need to be a registered and drilled Rat with an identified IRC nickname to use this command."
-
 def getRatId(bot, ratname, platform=None):
 
     if ratname in savedratids.keys():
@@ -313,7 +311,9 @@ def require_dispatch(message=None):
         return actual_decorator(message)
     return actual_decorator
 
-def require_rat(message=None):
+def require_rat(message="Sorry, but you need to be a registered and drilled Rat with an identified IRC nickname to use "
+                        "this command."
+):
     """Decorate a function to require the triggering user to be a FuelRats rat (as in, registered with the API and drilled).
     If they are not, `message` will be said if given."""
     def actual_decorator(function):

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -274,7 +274,7 @@ def require_op(message="This command is restricted for Ops and above."):
         return actual_decorator(message)
     return actual_decorator
 
-def require_overseer(message=None):
+def require_overseer(message='Sorry pal, you\'re not an overseer or higher!'):
     """Decorate a function to require the triggering user to be a FuelRats overseer (as in, a highly experienced and trustworthy person).
     If they are not, `message` will be said if given."""
     def actual_decorator(function):

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -481,7 +481,7 @@ def updateBoardIndexes(bot):
         save_case(bot, rescue, forceFull=True)
 
 @commands('reindex', 'updateindex', 'index', 'ri')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_reindex(bot, trigger):
     """
     Updates all Indexes with the API (/Dispatch Board)
@@ -769,7 +769,7 @@ def prepsent(bot, trigger):
 @commands('quote')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_quote(bot, trigger, rescue):
     """
     Recites all known information for the specified rescue
@@ -830,7 +830,7 @@ def func_quote(bot, trigger, rescue, showboardindex=True):
 @commands('clear', 'close')
 # @ratlib.sopel.filter_output
 @parameterize('r*', '<client name or case number> [Rat that fired first limpet]')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_clear(bot, trigger, rescue, *firstlimpet):
     """
     Mark a case as closed.
@@ -899,7 +899,7 @@ def func_clear(bot, trigger, rescue, markingForDeletion=False, *firstlimpet):
 @commands('list')
 @ratlib.sopel.filter_output
 @parameterize('w', usage="[-iru@]")
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_list(bot, trigger, params=''):
     """
     List the currently active, open cases.
@@ -1025,7 +1025,7 @@ def format_rescue(bot, rescue, attr='client_name', showassigned=False, showids=T
 @commands('grab')
 @ratlib.sopel.filter_output
 @parameterize('w', usage='<client name>')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_grab(bot, trigger, client):
     """
     Grab the last line the client said and add it to the case.
@@ -1067,7 +1067,7 @@ def cmd_grab(bot, trigger, client):
 
 @commands('inject')
 @parameterize("wT", usage="<client or case number> <text to add>")
-@require_rat(msg_not_idented)
+@require_rat()
 # Using this to prevent cases from created if they are not found, therefor created, but no line to add was specified.
 def cmd_inject(bot, trigger, case, line):
     """
@@ -1111,7 +1111,7 @@ def func_inject(bot, trigger, find_result, line):
 @commands('sub')
 @ratlib.sopel.filter_output
 @parameterize('rwT', usage='<client or case number> <line number> [<replacement text>]')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_sub(bot, trigger, rescue, lineno, line=None):
     """
     Substitute or delete an existing line of text to the client's case.  Does not perform autocorrection/autodetection
@@ -1141,7 +1141,7 @@ def cmd_sub(bot, trigger, rescue, lineno, line=None):
 @commands('active', 'activate', 'inactive', 'deactivate')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_active(bot, trigger, rescue):
     """
     Toggle a case active/inactive
@@ -1159,7 +1159,7 @@ def cmd_active(bot, trigger, rescue):
 @commands('epic')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_epic(bot, trigger, rescue):
     """
     Toggle a case epic/not epic
@@ -1179,7 +1179,7 @@ def cmd_epic(bot, trigger, rescue):
 @commands('assign', 'add', 'go')
 @ratlib.sopel.filter_output
 @parameterize('r+', usage="<client or case number> <rats...>")
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_assign(bot, trigger, rescue, *rats):
     """
     Assign rats to a client's case.
@@ -1223,7 +1223,7 @@ def cmd_assign(bot, trigger, rescue, *rats):
 @commands('ratid', 'id')
 @ratlib.sopel.filter_output
 @parameterize('w', usage='<ratname>')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_ratid(bot, trigger, rat):
     """
     Get a rats' id from the api
@@ -1237,7 +1237,7 @@ def cmd_ratid(bot, trigger, rat):
 @commands('unassign', 'deassign', 'rm', 'remove', 'standdown')
 @ratlib.sopel.filter_output
 @parameterize('r+', usage="<client or case number> <rats...>")
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_unassign(bot, trigger, rescue, *rats):
     """
     Remove rats from a client's case.
@@ -1265,7 +1265,7 @@ def cmd_unassign(bot, trigger, rescue, *rats):
 @commands('codered', 'casered', 'cr')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_codered(bot, trigger, rescue):
     """
     Toggles the code red status of a case.
@@ -1288,7 +1288,7 @@ def cmd_codered(bot, trigger, rescue):
 
 
 @requires_case
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_platform(bot, trigger, rescue, platform=None):
     """
     Sets a case platform to PC or xbox.
@@ -1308,20 +1308,20 @@ def cmd_platform(bot, trigger, rescue, platform=None):
 
 # For some reason, this can't be tricked with functools.partial.
 @commands('pc')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_platform_pc(bot, trigger):
     """Sets a case's platform to PC"""
     return cmd_platform(bot, trigger, platform='pc')
 
 
 @commands('xb(?:ox)?(?:-?(?:1|one))?')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_platform_xb(bot, trigger):
     """Sets a case's platform to XB"""
     return cmd_platform(bot, trigger, platform='xb')
 
 @commands('ps(?:4)?')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_plaform_ps(bot, trigger):
     """Sets a case's platform to PlayStation"""
     if bot.config.ratboard.enable_ps_support == 'True' or False:
@@ -1333,7 +1333,7 @@ def cmd_plaform_ps(bot, trigger):
 @ratlib.sopel.filter_output
 @parameterize('rT', usage='<client or case number> <system name>')
 @ratlib.db.with_session
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_system(bot, trigger, rescue, system, db=None):
     """
     Sets a case's system.
@@ -1366,7 +1366,7 @@ def cmd_system(bot, trigger, rescue, system, db=None):
 @ratlib.sopel.filter_output
 @parameterize('rT', usage='<client or case number> <commander namename>')
 @ratlib.db.with_session
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_commander(bot, trigger, rescue, commander, db=None):
     """
     Sets a client's in-game commander name.
@@ -1526,7 +1526,7 @@ def ratmama_parse(bot, trigger, db):
 
 
 @commands('closed', 'recent')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_closed(bot, trigger):
     '''
     Lists the 5 last closed rescues to give the ability to reopen them
@@ -1662,7 +1662,7 @@ def cmd_quoteid(bot, trigger, id):
 
 @commands('title')
 @parameterize('rw*', '<case # or client name> <title to set>')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_title(bot, trigger, rescue, *title):
     """
     Sets the Operation Title of a rescue.
@@ -1678,7 +1678,7 @@ def cmd_title(bot, trigger, rescue, *title):
 
 @commands('pwl', 'pwlink', 'paperwork', 'paperworklink')
 @parameterize(params='r', usage='<client name or case number>')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_pwl(bot, trigger, case):
     """
     Creates the link for the paperwork of any currently open rescue and shortens it (if the shortener module is active)
@@ -1712,7 +1712,7 @@ def cmd_version(bot, trigger):
 
 
 @commands('flush', 'resetnames', 'rn', 'flushnames', 'fn')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_flush(bot, trigger):
     """
     Resets the cached RatNames. Helps with Bugged rat names on !assign
@@ -1771,7 +1771,7 @@ def setRescueMarkedForDeletion(bot, rescue, marked, reason='None.', reporter='No
 
 @commands('md', 'mdadd', 'markfordeletion', 'markfordelete')
 @parameterize('rt', '<client/board #> <reason>')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_md(bot, trigger, case, reason):
     """
     Closes a rescue and adds it to the Marked for Deletion List™
@@ -1812,7 +1812,7 @@ def cmd_mdremove(bot, trigger, caseid):
 
 @commands('ircnick', 'nick', 'nickname')
 @parameterize('rt')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_nick(bot, trigger, case, newnick):
     """
     Sets a new nickname for this case.
@@ -1823,7 +1823,7 @@ def cmd_nick(bot, trigger, case, newnick):
     bot.say('Set Nick to ' + str(newnick))
 
 @commands('quiet', 'lastsignal', 'last')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_quiet(bot, trigger):
     """
     Tells the time since the last Signal
@@ -1900,7 +1900,7 @@ def prepexpired(bot):
     bot.say("Caution: The most recent client has NOT been !prep-ed!")
 
 @commands('paperworkneeded', 'needspaperwork', 'npw', 'pwn')
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_pwn(bot, trigger):
     '''
     Lists all cases with incomplete paperwork

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -63,6 +63,8 @@ def dummymethod():
     pass
 preptimer = Timer(0, dummymethod)
 
+# defining this here, so it does not have to be redefined every time a new @requirerat command is made
+notRatIdented = "Sorry, but you need to be a registered and drilled Rat with an identified IRC nickname to use this command."
 ## Start setup section ###
 class RatboardSection(StaticSection):
     signal = ValidatedAttribute('signal', str, default='ratsignal')
@@ -86,6 +88,7 @@ def setup(bot):
     bot.memory['ratbot']['board'] = RescueBoard()
     bot.memory['ratbot']['board'].bot = bot
     bot.memory['ratbot']['lastsignal'] = None
+    bot.memory['ratbot']['lastCase'] = None  # store the last case in memory
 
     if not hasattr(bot.config, 'ratboard') or not bot.config.ratboard.signal:
         signal = 'ratsignal'
@@ -480,7 +483,7 @@ def updateBoardIndexes(bot):
         save_case(bot, rescue, forceFull=True)
 
 @commands('reindex', 'updateindex', 'index', 'ri')
-@require_rat('You need to be a registered and drilled Rat to execute this command!')
+@require_rat(notRatIdented)
 def cmd_reindex(bot, trigger):
     """
     Updates all Indexes with the API (/Dispatch Board)
@@ -768,7 +771,7 @@ def prepsent(bot, trigger):
 @commands('quote')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_quote(bot, trigger, rescue):
     """
     Recites all known information for the specified rescue
@@ -829,7 +832,7 @@ def func_quote(bot, trigger, rescue, showboardindex=True):
 @commands('clear', 'close')
 # @ratlib.sopel.filter_output
 @parameterize('r*', '<client name or case number> [Rat that fired first limpet]')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_clear(bot, trigger, rescue, *firstlimpet):
     """
     Mark a case as closed.
@@ -898,7 +901,7 @@ def func_clear(bot, trigger, rescue, markingForDeletion=False, *firstlimpet):
 @commands('list')
 @ratlib.sopel.filter_output
 @parameterize('w', usage="[-iru@]")
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_list(bot, trigger, params=''):
     """
     List the currently active, open cases.
@@ -1024,7 +1027,7 @@ def format_rescue(bot, rescue, attr='client_name', showassigned=False, showids=T
 @commands('grab')
 @ratlib.sopel.filter_output
 @parameterize('w', usage='<client name>')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_grab(bot, trigger, client):
     """
     Grab the last line the client said and add it to the case.
@@ -1048,6 +1051,7 @@ def cmd_grab(bot, trigger, client):
         with bot.memory['ratbot']['board'].change(result.rescue):
             result.rescue.data.update(defaultdata)
             result.rescue.data.update({'IRCNick': result.rescue.client, "boardIndex": int(result.rescue.boardindex)})
+            bot.memory['ratbot']['lastCase'] = result.rescue  # wait... this doesn't fire prepcr does it?
 
     bot.say(
         "{rescue.client_name}'s case {verb} with: \"{line}\"  ({tags})"
@@ -1065,7 +1069,7 @@ def cmd_grab(bot, trigger, client):
 
 @commands('inject')
 @parameterize("wT", usage="<client or case number> <text to add>")
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 # Using this to prevent cases from created if they are not found, therefor created, but no line to add was specified.
 def cmd_inject(bot, trigger, case, line):
     """
@@ -1109,7 +1113,7 @@ def func_inject(bot, trigger, find_result, line):
 @commands('sub')
 @ratlib.sopel.filter_output
 @parameterize('rwT', usage='<client or case number> <line number> [<replacement text>]')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_sub(bot, trigger, rescue, lineno, line=None):
     """
     Substitute or delete an existing line of text to the client's case.  Does not perform autocorrection/autodetection
@@ -1139,7 +1143,7 @@ def cmd_sub(bot, trigger, rescue, lineno, line=None):
 @commands('active', 'activate', 'inactive', 'deactivate')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_active(bot, trigger, rescue):
     """
     Toggle a case active/inactive
@@ -1157,7 +1161,7 @@ def cmd_active(bot, trigger, rescue):
 @commands('epic')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_epic(bot, trigger, rescue):
     """
     Toggle a case epic/not epic
@@ -1177,7 +1181,7 @@ def cmd_epic(bot, trigger, rescue):
 @commands('assign', 'add', 'go')
 @ratlib.sopel.filter_output
 @parameterize('r+', usage="<client or case number> <rats...>")
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_assign(bot, trigger, rescue, *rats):
     """
     Assign rats to a client's case.
@@ -1221,7 +1225,7 @@ def cmd_assign(bot, trigger, rescue, *rats):
 @commands('ratid', 'id')
 @ratlib.sopel.filter_output
 @parameterize('w', usage='<ratname>')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_ratid(bot, trigger, rat):
     """
     Get a rats' id from the api
@@ -1235,7 +1239,7 @@ def cmd_ratid(bot, trigger, rat):
 @commands('unassign', 'deassign', 'rm', 'remove', 'standdown')
 @ratlib.sopel.filter_output
 @parameterize('r+', usage="<client or case number> <rats...>")
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_unassign(bot, trigger, rescue, *rats):
     """
     Remove rats from a client's case.
@@ -1263,7 +1267,7 @@ def cmd_unassign(bot, trigger, rescue, *rats):
 @commands('codered', 'casered', 'cr')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_codered(bot, trigger, rescue):
     """
     Toggles the code red status of a case.
@@ -1286,7 +1290,7 @@ def cmd_codered(bot, trigger, rescue):
 
 
 @requires_case
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_platform(bot, trigger, rescue, platform=None):
     """
     Sets a case platform to PC or xbox.
@@ -1306,20 +1310,20 @@ def cmd_platform(bot, trigger, rescue, platform=None):
 
 # For some reason, this can't be tricked with functools.partial.
 @commands('pc')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_platform_pc(bot, trigger):
     """Sets a case's platform to PC"""
     return cmd_platform(bot, trigger, platform='pc')
 
 
 @commands('xb(?:ox)?(?:-?(?:1|one))?')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_platform_xb(bot, trigger):
     """Sets a case's platform to XB"""
     return cmd_platform(bot, trigger, platform='xb')
 
 @commands('ps(?:4)?')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_plaform_ps(bot, trigger):
     """Sets a case's platform to PlayStation"""
     if bot.config.ratboard.enable_ps_support == 'True' or False:
@@ -1331,7 +1335,7 @@ def cmd_plaform_ps(bot, trigger):
 @ratlib.sopel.filter_output
 @parameterize('rT', usage='<client or case number> <system name>')
 @ratlib.db.with_session
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_system(bot, trigger, rescue, system, db=None):
     """
     Sets a case's system.
@@ -1364,7 +1368,7 @@ def cmd_system(bot, trigger, rescue, system, db=None):
 @ratlib.sopel.filter_output
 @parameterize('rT', usage='<client or case number> <commander namename>')
 @ratlib.db.with_session
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_commander(bot, trigger, rescue, commander, db=None):
     """
     Sets a client's in-game commander name.
@@ -1524,7 +1528,7 @@ def ratmama_parse(bot, trigger, db):
 
 
 @commands('closed', 'recent')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_closed(bot, trigger):
     '''
     Lists the 5 last closed rescues to give the ability to reopen them
@@ -1660,7 +1664,7 @@ def cmd_quoteid(bot, trigger, id):
 
 @commands('title')
 @parameterize('rw*', '<case # or client name> <title to set>')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_title(bot, trigger, rescue, *title):
     """
     Sets the Operation Title of a rescue.
@@ -1676,7 +1680,7 @@ def cmd_title(bot, trigger, rescue, *title):
 
 @commands('pwl', 'pwlink', 'paperwork', 'paperworklink')
 @parameterize(params='r', usage='<client name or case number>')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_pwl(bot, trigger, case):
     """
     Creates the link for the paperwork of any currently open rescue and shortens it (if the shortener module is active)
@@ -1710,7 +1714,7 @@ def cmd_version(bot, trigger):
 
 
 @commands('flush', 'resetnames', 'rn', 'flushnames', 'fn')
-@require_rat('Sorry, you need to be a registered and drilled rat to access this command.')
+@require_rat(notRatIdented)
 def cmd_flush(bot, trigger):
     """
     Resets the cached RatNames. Helps with Bugged rat names on !assign
@@ -1769,7 +1773,7 @@ def setRescueMarkedForDeletion(bot, rescue, marked, reason='None.', reporter='No
 
 @commands('md', 'mdadd', 'markfordeletion', 'markfordelete')
 @parameterize('rt', '<client/board #> <reason>')
-@require_rat('Sorry, but you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_md(bot, trigger, case, reason):
     """
     Closes a rescue and adds it to the Marked for Deletion List™
@@ -1810,7 +1814,7 @@ def cmd_mdremove(bot, trigger, caseid):
 
 @commands('ircnick', 'nick', 'nickname')
 @parameterize('rt')
-@require_rat('Sorry, but you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_nick(bot, trigger, case, newnick):
     """
     Sets a new nickname for this case.
@@ -1821,7 +1825,7 @@ def cmd_nick(bot, trigger, case, newnick):
     bot.say('Set Nick to ' + str(newnick))
 
 @commands('quiet', 'lastsignal', 'last')
-@require_rat('Sorry, but you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_quiet(bot, trigger):
     """
     Tells the time since the last Signal
@@ -1898,7 +1902,7 @@ def prepexpired(bot):
     bot.say("Caution: The most recent client has NOT been !prep-ed!")
 
 @commands('paperworkneeded', 'needspaperwork', 'npw', 'pwn')
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(notRatIdented)
 def cmd_pwn(bot, trigger):
     '''
     Lists all cases with incomplete paperwork

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -86,7 +86,6 @@ def setup(bot):
     bot.memory['ratbot']['board'] = RescueBoard()
     bot.memory['ratbot']['board'].bot = bot
     bot.memory['ratbot']['lastsignal'] = None
-    bot.memory['ratbot']['lastCase'] = None  # store the last case in memory
 
     if not hasattr(bot.config, 'ratboard') or not bot.config.ratboard.signal:
         signal = 'ratsignal'
@@ -1049,7 +1048,6 @@ def cmd_grab(bot, trigger, client):
         with bot.memory['ratbot']['board'].change(result.rescue):
             result.rescue.data.update(defaultdata)
             result.rescue.data.update({'IRCNick': result.rescue.client, "boardIndex": int(result.rescue.boardindex)})
-            bot.memory['ratbot']['lastCase'] = result.rescue  # wait... this doesn't fire prepcr does it?
 
     bot.say(
         "{rescue.client_name}'s case {verb} with: \"{line}\"  ({tags})"

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -1573,7 +1573,7 @@ def getDummyRescue():
 
 @commands('reopen')
 @parameterize('+', usage="<id>")
-@require_overseer('Sorry pal, you\'re not an overseer or higher!')
+@require_overseer()
 def cmd_reopen(bot, trigger, id):
     """
     Reopens a case by its full database ID
@@ -1589,7 +1589,7 @@ def cmd_reopen(bot, trigger, id):
 
 
 @commands('delete')
-@require_overseer(message='Sorry pal, you\'re not an overseer or higher!')
+@require_overseer()
 @parameterize('+', usage='<id/list>')
 def cmd_delete(bot, trigger, id):
     """
@@ -1631,7 +1631,7 @@ def func_delete(bot, trigger, id):
 
 
 @commands('mdlist')
-@require_overseer('Sorry pal, you\'re not an overseer or higher!')
+@require_overseer()
 def cmd_mdlist(bot, trigger):
     """
     Shows the Marked for Deletion List™
@@ -1642,7 +1642,7 @@ def cmd_mdlist(bot, trigger):
 @commands('quoteid')
 @ratlib.sopel.filter_output
 @parameterize('+', usage='<id>')
-@require_overseer('Sorry pal, you\'re not an overseer or higher!')
+@require_overseer()
 def cmd_quoteid(bot, trigger, id):
     """
     Quotes a case by its database id
@@ -1731,7 +1731,7 @@ def cmd_host(bot, trigger):
 
 
 @commands('refreshboard', 'resetboard', 'forceresetboard', 'forcerefreshboard', 'frb', 'fbr', 'boardrefresh')
-@require_overseer('Sorry, but you need to be a registered Overseer or higher to access this command.')
+@require_overseer()
 def cmd_forceRefreshBoard(bot, trigger):
     """
     Forcefully resets the Board. This removes all "Ghost" Cases as they are grabbed from the API. Boardindexes will get changed by , but updated on the Dispatch Board afterwards.
@@ -1789,7 +1789,7 @@ def cmd_md(bot, trigger, case, reason):
 
 @commands('mdremove', 'mdr', 'mdd', 'mddeny')
 @parameterize('w', '<id>')
-@require_overseer('Sorry, but you need to be an overseer or higher to use this command!')
+@require_overseer()
 def cmd_mdremove(bot, trigger, caseid):
     """
     Remove a case from the Marked for Deletion List™ (Does NOT reopen the case!)
@@ -1934,7 +1934,7 @@ def cmd_pwn(bot, trigger):
 
 @commands('invalid', 'invalidate')
 @parameterize('w', '<id>')
-@require_overseer('Sorry, but you need to be an overseer or higher to use this command!')
+@require_overseer()
 def cmd_invalid(bot, trigger, caseid):
     """
     Remove a case from the Marked for Deletion List™ (Does NOT reopen the case!)

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -63,8 +63,6 @@ def dummymethod():
     pass
 preptimer = Timer(0, dummymethod)
 
-# defining this here, so it does not have to be redefined every time a new @requirerat command is made
-notRatIdented = "Sorry, but you need to be a registered and drilled Rat with an identified IRC nickname to use this command."
 ## Start setup section ###
 class RatboardSection(StaticSection):
     signal = ValidatedAttribute('signal', str, default='ratsignal')
@@ -483,7 +481,7 @@ def updateBoardIndexes(bot):
         save_case(bot, rescue, forceFull=True)
 
 @commands('reindex', 'updateindex', 'index', 'ri')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_reindex(bot, trigger):
     """
     Updates all Indexes with the API (/Dispatch Board)
@@ -771,7 +769,7 @@ def prepsent(bot, trigger):
 @commands('quote')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_quote(bot, trigger, rescue):
     """
     Recites all known information for the specified rescue
@@ -832,7 +830,7 @@ def func_quote(bot, trigger, rescue, showboardindex=True):
 @commands('clear', 'close')
 # @ratlib.sopel.filter_output
 @parameterize('r*', '<client name or case number> [Rat that fired first limpet]')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_clear(bot, trigger, rescue, *firstlimpet):
     """
     Mark a case as closed.
@@ -901,7 +899,7 @@ def func_clear(bot, trigger, rescue, markingForDeletion=False, *firstlimpet):
 @commands('list')
 @ratlib.sopel.filter_output
 @parameterize('w', usage="[-iru@]")
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_list(bot, trigger, params=''):
     """
     List the currently active, open cases.
@@ -1027,7 +1025,7 @@ def format_rescue(bot, rescue, attr='client_name', showassigned=False, showids=T
 @commands('grab')
 @ratlib.sopel.filter_output
 @parameterize('w', usage='<client name>')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_grab(bot, trigger, client):
     """
     Grab the last line the client said and add it to the case.
@@ -1069,7 +1067,7 @@ def cmd_grab(bot, trigger, client):
 
 @commands('inject')
 @parameterize("wT", usage="<client or case number> <text to add>")
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 # Using this to prevent cases from created if they are not found, therefor created, but no line to add was specified.
 def cmd_inject(bot, trigger, case, line):
     """
@@ -1113,7 +1111,7 @@ def func_inject(bot, trigger, find_result, line):
 @commands('sub')
 @ratlib.sopel.filter_output
 @parameterize('rwT', usage='<client or case number> <line number> [<replacement text>]')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_sub(bot, trigger, rescue, lineno, line=None):
     """
     Substitute or delete an existing line of text to the client's case.  Does not perform autocorrection/autodetection
@@ -1143,7 +1141,7 @@ def cmd_sub(bot, trigger, rescue, lineno, line=None):
 @commands('active', 'activate', 'inactive', 'deactivate')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_active(bot, trigger, rescue):
     """
     Toggle a case active/inactive
@@ -1161,7 +1159,7 @@ def cmd_active(bot, trigger, rescue):
 @commands('epic')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_epic(bot, trigger, rescue):
     """
     Toggle a case epic/not epic
@@ -1181,7 +1179,7 @@ def cmd_epic(bot, trigger, rescue):
 @commands('assign', 'add', 'go')
 @ratlib.sopel.filter_output
 @parameterize('r+', usage="<client or case number> <rats...>")
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_assign(bot, trigger, rescue, *rats):
     """
     Assign rats to a client's case.
@@ -1225,7 +1223,7 @@ def cmd_assign(bot, trigger, rescue, *rats):
 @commands('ratid', 'id')
 @ratlib.sopel.filter_output
 @parameterize('w', usage='<ratname>')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_ratid(bot, trigger, rat):
     """
     Get a rats' id from the api
@@ -1239,7 +1237,7 @@ def cmd_ratid(bot, trigger, rat):
 @commands('unassign', 'deassign', 'rm', 'remove', 'standdown')
 @ratlib.sopel.filter_output
 @parameterize('r+', usage="<client or case number> <rats...>")
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_unassign(bot, trigger, rescue, *rats):
     """
     Remove rats from a client's case.
@@ -1267,7 +1265,7 @@ def cmd_unassign(bot, trigger, rescue, *rats):
 @commands('codered', 'casered', 'cr')
 @ratlib.sopel.filter_output
 @requires_case
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_codered(bot, trigger, rescue):
     """
     Toggles the code red status of a case.
@@ -1290,7 +1288,7 @@ def cmd_codered(bot, trigger, rescue):
 
 
 @requires_case
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_platform(bot, trigger, rescue, platform=None):
     """
     Sets a case platform to PC or xbox.
@@ -1310,20 +1308,20 @@ def cmd_platform(bot, trigger, rescue, platform=None):
 
 # For some reason, this can't be tricked with functools.partial.
 @commands('pc')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_platform_pc(bot, trigger):
     """Sets a case's platform to PC"""
     return cmd_platform(bot, trigger, platform='pc')
 
 
 @commands('xb(?:ox)?(?:-?(?:1|one))?')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_platform_xb(bot, trigger):
     """Sets a case's platform to XB"""
     return cmd_platform(bot, trigger, platform='xb')
 
 @commands('ps(?:4)?')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_plaform_ps(bot, trigger):
     """Sets a case's platform to PlayStation"""
     if bot.config.ratboard.enable_ps_support == 'True' or False:
@@ -1335,7 +1333,7 @@ def cmd_plaform_ps(bot, trigger):
 @ratlib.sopel.filter_output
 @parameterize('rT', usage='<client or case number> <system name>')
 @ratlib.db.with_session
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_system(bot, trigger, rescue, system, db=None):
     """
     Sets a case's system.
@@ -1368,7 +1366,7 @@ def cmd_system(bot, trigger, rescue, system, db=None):
 @ratlib.sopel.filter_output
 @parameterize('rT', usage='<client or case number> <commander namename>')
 @ratlib.db.with_session
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_commander(bot, trigger, rescue, commander, db=None):
     """
     Sets a client's in-game commander name.
@@ -1528,7 +1526,7 @@ def ratmama_parse(bot, trigger, db):
 
 
 @commands('closed', 'recent')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_closed(bot, trigger):
     '''
     Lists the 5 last closed rescues to give the ability to reopen them
@@ -1664,7 +1662,7 @@ def cmd_quoteid(bot, trigger, id):
 
 @commands('title')
 @parameterize('rw*', '<case # or client name> <title to set>')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_title(bot, trigger, rescue, *title):
     """
     Sets the Operation Title of a rescue.
@@ -1680,7 +1678,7 @@ def cmd_title(bot, trigger, rescue, *title):
 
 @commands('pwl', 'pwlink', 'paperwork', 'paperworklink')
 @parameterize(params='r', usage='<client name or case number>')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_pwl(bot, trigger, case):
     """
     Creates the link for the paperwork of any currently open rescue and shortens it (if the shortener module is active)
@@ -1714,7 +1712,7 @@ def cmd_version(bot, trigger):
 
 
 @commands('flush', 'resetnames', 'rn', 'flushnames', 'fn')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_flush(bot, trigger):
     """
     Resets the cached RatNames. Helps with Bugged rat names on !assign
@@ -1773,7 +1771,7 @@ def setRescueMarkedForDeletion(bot, rescue, marked, reason='None.', reporter='No
 
 @commands('md', 'mdadd', 'markfordeletion', 'markfordelete')
 @parameterize('rt', '<client/board #> <reason>')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_md(bot, trigger, case, reason):
     """
     Closes a rescue and adds it to the Marked for Deletion List™
@@ -1814,7 +1812,7 @@ def cmd_mdremove(bot, trigger, caseid):
 
 @commands('ircnick', 'nick', 'nickname')
 @parameterize('rt')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_nick(bot, trigger, case, newnick):
     """
     Sets a new nickname for this case.
@@ -1825,7 +1823,7 @@ def cmd_nick(bot, trigger, case, newnick):
     bot.say('Set Nick to ' + str(newnick))
 
 @commands('quiet', 'lastsignal', 'last')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_quiet(bot, trigger):
     """
     Tells the time since the last Signal
@@ -1902,7 +1900,7 @@ def prepexpired(bot):
     bot.say("Caution: The most recent client has NOT been !prep-ed!")
 
 @commands('paperworkneeded', 'needspaperwork', 'npw', 'pwn')
-@require_rat(notRatIdented)
+@require_rat(msg_not_idented)
 def cmd_pwn(bot, trigger):
     '''
     Lists all cases with incomplete paperwork

--- a/sopel-modules/rat-facts.py
+++ b/sopel-modules/rat-facts.py
@@ -242,7 +242,7 @@ def cmd_fact(bot, trigger, db=None):
             return
         return bot.say(line)
 
-    @require_overseer('Sorry, but you need to be an overseer or higher to execute this command.')
+    @require_overseer()
     def cmd_fact_import(bot, trigger):
         import_facts(bot, merge=(option == '-f'))
         return bot.say("Facts imported.")
@@ -251,7 +251,7 @@ def cmd_fact(bot, trigger, db=None):
         return cmd_fact_import(bot, trigger)
 
 
-    @require_overseer('Sorry, but you need to be an overseer or higher to execute this command.')
+    @require_overseer()
     def cmd_fact_edit(bot, trigger):
         if not option:
             bot.reply("Missing fact.")

--- a/sopel-modules/rat-search.py
+++ b/sopel-modules/rat-search.py
@@ -36,7 +36,7 @@ from ratlib.db import with_session, Starsystem, StarsystemPrefix, Landmark, get_
 from ratlib.starsystem import refresh_database, scan_for_systems, ConcurrentOperationError
 from ratlib.autocorrect import correct
 import re
-from ratlib.api.names import require_rat, require_overseer
+from ratlib.api.names import require_rat, require_overseer, msg_not_idented
 from ratlib.hastebin import post_to_hastebin
 from ratlib.util import timed
 
@@ -241,7 +241,7 @@ def cmd_scan(bot, trigger):
 
 
 @commands('plot')
-@require_rat('You need to be a registered and drilled Rat to use this Command!')
+@require_rat(msg_not_idented)
 # @rate(60 * 30)
 @with_session
 def cmd_plot(bot, trigger, db=None):
@@ -379,7 +379,7 @@ def cmd_plot(bot, trigger, db=None):
 
 
 @commands('landmark')
-@require_rat('You need to be a registered and drilled Rat to use this Command!')
+@require_rat(msg_not_idented)
 @with_session
 def cmd_landmark(bot, trigger, db=None):
     """

--- a/sopel-modules/rat-search.py
+++ b/sopel-modules/rat-search.py
@@ -442,7 +442,7 @@ def cmd_landmark(bot, trigger, db=None):
             .format(starsystem=starsystem, landmark=landmark, distance=distance)
         )
 
-    @require_overseer
+    @require_overseer(None)
     def subcommand_add(*unused_args, **unused_kwargs):
         starsystem = get_system_or_none(system_name)
         if not starsystem:
@@ -457,7 +457,7 @@ def cmd_landmark(bot, trigger, db=None):
         else:
             bot.reply("Added system '{}' as a landmark.".format(starsystem.name))
 
-    @require_overseer
+    @require_overseer(None)
     def subcommand_del(*unused_args, **unused_kwargs):
         landmark = lookup_system(system_name, Landmark)
         if landmark is None:
@@ -468,7 +468,7 @@ def cmd_landmark(bot, trigger, db=None):
         bot.reply("Removed system '{}' from the list of landmarks.".format(landmark.name))
         pass
 
-    @require_overseer
+    @require_overseer(None)
     def subcommand_refresh(*unused_args, **unused_kwargs):
         ct = (
             db.query(Landmark)

--- a/sopel-modules/rat-search.py
+++ b/sopel-modules/rat-search.py
@@ -36,7 +36,7 @@ from ratlib.db import with_session, Starsystem, StarsystemPrefix, Landmark, get_
 from ratlib.starsystem import refresh_database, scan_for_systems, ConcurrentOperationError
 from ratlib.autocorrect import correct
 import re
-from ratlib.api.names import require_rat, require_overseer, msg_not_idented
+from ratlib.api.names import require_rat, require_overseer
 from ratlib.hastebin import post_to_hastebin
 from ratlib.util import timed
 
@@ -241,7 +241,7 @@ def cmd_scan(bot, trigger):
 
 
 @commands('plot')
-@require_rat(msg_not_idented)
+@require_rat()
 # @rate(60 * 30)
 @with_session
 def cmd_plot(bot, trigger, db=None):
@@ -379,7 +379,7 @@ def cmd_plot(bot, trigger, db=None):
 
 
 @commands('landmark')
-@require_rat(msg_not_idented)
+@require_rat()
 @with_session
 def cmd_landmark(bot, trigger, db=None):
     """

--- a/sopel-modules/rat-socket.py
+++ b/sopel-modules/rat-socket.py
@@ -151,7 +151,7 @@ def sockettest(bot, trigger):
 
 
 @commands('connectsocket', 'connect')
-@require_techrat('I am sorry, but this command is restricted for TechRats and above.')
+@require_techrat()
 @ratlib.sopel.filter_output
 def connectSocket(bot, trigger):
     """

--- a/sopel-modules/rat-twitter.py
+++ b/sopel-modules/rat-twitter.py
@@ -23,7 +23,7 @@ from sopel.module import commands
 from twitter import TwitterError
 
 import ratlib.sopel
-from ratlib.api.names import require_rat, require_techrat
+from ratlib.api.names import require_rat, require_techrat, msg_not_idented
 from ratlib.db import with_session, Starsystem
 from ratlib.sopel import parameterize
 
@@ -103,7 +103,7 @@ def cmd_tweetdebug(bot, trigger):
 
 @commands('tweet')
 @parameterize("t", usage="<text to tweet>")
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(msg_not_idented)
 def cmd_tweet(bot, trigger, line):
     """ 
     Tweet your heart out! (Serious messages though!) 
@@ -200,7 +200,7 @@ def get_tweet_for_case(rescue, db):
 @commands('tweetcase','tweetc')
 @parameterize('r', usage='<client or case number>')
 @with_session
-@require_rat('Sorry, you need to be a registered and drilled Rat to use this command.')
+@require_rat(msg_not_idented)
 def cmd_tweetc(bot, trigger, rescue, db = None):
     """
     Send a tweet based on a case, using generic terms (in bubble, near landmark).

--- a/sopel-modules/rat-twitter.py
+++ b/sopel-modules/rat-twitter.py
@@ -23,7 +23,7 @@ from sopel.module import commands
 from twitter import TwitterError
 
 import ratlib.sopel
-from ratlib.api.names import require_rat, require_techrat, msg_not_idented
+from ratlib.api.names import require_rat, require_techrat
 from ratlib.db import with_session, Starsystem
 from ratlib.sopel import parameterize
 
@@ -103,7 +103,7 @@ def cmd_tweetdebug(bot, trigger):
 
 @commands('tweet')
 @parameterize("t", usage="<text to tweet>")
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_tweet(bot, trigger, line):
     """ 
     Tweet your heart out! (Serious messages though!) 
@@ -200,7 +200,7 @@ def get_tweet_for_case(rescue, db):
 @commands('tweetcase','tweetc')
 @parameterize('r', usage='<client or case number>')
 @with_session
-@require_rat(msg_not_idented)
+@require_rat()
 def cmd_tweetc(bot, trigger, rescue, db = None):
     """
     Send a tweet based on a case, using generic terms (in bubble, near landmark).

--- a/sopel-modules/rat-twitter.py
+++ b/sopel-modules/rat-twitter.py
@@ -89,7 +89,7 @@ def requires_case(fn):
     return parameterize('r', "<client or case number>")(fn)
 
 @commands('tweetdebug')
-@require_techrat
+@require_techrat(None)
 def cmd_tweetdebug(bot, trigger):
     """
     Toggles debug mode on and off. Does not save when the bot is reloaded.


### PR DESCRIPTION
Fixes MECHA-230 by replacing all instances of `'You need to be a registered and drilled Rat to execute this command!'`, `'Sorry, you need to be a registered and drilled Rat to use this command.'` and `'Sorry, but you need to be a registered and drilled Rat to use this command.'` with the variable `api.names.msg_not_idented`.

`api.names.msg_not_idented` is defined as string `"Sorry, but you need to be a registered and drilled Rat with an identified IRC nickname to use this command."`

The reason i redefined all the hardcoded strings to a variable is because it increases uniformity (we had 3 different messages stating the same thing!) and makes it more maintainable. If i went and search-replaced all the hardcoded string instances the next change would also have to be search-replace. Placing it as a single var means we just have to edit the string in one place rather than `n` cases

Update:
-------------
Refactored each `@require_{role}` decorator to have a default message, and changed all decorated instances to use the default, excluding those that specifically had no message.