### PR TITLE
Timezone Awareness Fix.

### DIFF
--- a/ratlib/timeutil.py
+++ b/ratlib/timeutil.py
@@ -24,7 +24,10 @@ def friendly_timedelta(delta):
     Assumes negative values are in the past, positive values in the future.
     """
     if isinstance(delta, datetime.datetime):
-        return friendly_timedelta(delta - datetime.datetime.now(tz=delta.tzinfo))
+        if delta.tzinfo:
+            return friendly_timedelta(delta - datetime.datetime.now(tz=delta.tzinfo))
+        else:
+            return friendly_timedelta(delta-datetime.datetime.utcnow())
     if isinstance(delta, datetime.date):
         return friendly_timedelta(delta - datetime.date.today())
 

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -813,7 +813,7 @@ def func_quote(bot, trigger, rescue, showboardindex=True):
     if rescue.unidentifiedRats:
         bot.say("Assigned unidentifiedRats: " + ", ".join(rescue.unidentifiedRats))
     for ix, quote in enumerate(rescue.quotes):
-        pdate = "unknown" if quote["updatedAt"] is None else pretty_date(dateutil.parser.parse(quote['updatedAt']))
+        pdate = "unknown" if quote["updatedAt"] is None else timeutil.friendly_timedelta(dateutil.parser.parse(quote['updatedAt']))
         if quote['lastAuthor'] is None:
             bot.say(
                 '[{ix}][{quote[author]} {ago}] {quote[message]}'.format(ix=ix, quote=quote, ago=pdate))


### PR DESCRIPTION
Fixes a bug with the `!quote` command of `rat-board` where it was possible to subtract a timezone-aware `datetime` object from a timezone-nieve `datetime` object

Basically that's not a thing that is permissible and raises an unhandled exception during command execution.
Props on Firebeam for reporting this.

Sidenote: why do we have both a `timeutils.friendly_timedelta` and a `pretty_timedelta` method?
Seems a little redundant.

Fixes MECHA-246