### PR TITLE
~~fixed~~ mitigated issue where IRCname != rat name

### DIFF
--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -61,9 +61,8 @@ def getRatId(bot, ratname, platform=None):
             tempnam = 'unknown name'
             tempplat = 'unknown platform'
             nicknames = firstmatch['nicknames']
-            tempAlias = []
-            for alias in nicknames:
-                tempAlias.append(alias.lower())
+            tempAlias = [name.lower() for name in nicknames]
+
             # print("looping over firstmatch['rats']...")
 
             for ratobject in firstmatch['rats']:

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -36,10 +36,10 @@ def getRatId(bot, ratname, platform=None):
         element = savedratids.get(ratname)
         strippedname = removeTags(ratname)
         if (platform is None) and ((str(element['name']).lower()==str(ratname).lower()) or str(element['name']).lower()==str(strippedname).lower() or str(element['name']).lower()==str(strippedname.replace('_',' ')).lower()):
-            print('platform was None and '+ratname+' was in keys and the name matched. returning '+str(element))
+            # print('platform was None and '+ratname+' was in keys and the name matched. returning '+str(element))
             return element
         elif (platform == element['platform']) and ((str(element['name']).lower()==str(ratname).lower()) or str(element['name']).lower()==str(strippedname).lower() or str(element['name']).lower()==str(strippedname.replace('_',' ')).lower()):
-            print('platform was on the gotten name and names matched. Returning '+str(element))
+            # print('platform was on the gotten name and names matched. Returning '+str(element))
             return element
 
 
@@ -71,7 +71,7 @@ def getRatId(bot, ratname, platform=None):
                 tempnam = ratobject['name']
                 tempplat = ratobject['platform']
 
-                print("tempnam = {}\ntempplat={}\n--------\nid={}".format(tempnam,tempplat, id))
+                # print("tempnam = {}\ntempplat={}\n--------\nid={}".format(tempnam,tempplat, id))
                 if (str(tempnam).lower()==str(ratname).lower()
                     or str(tempnam).lower()==str(strippedname).lower()
                     or str(tempnam).lower()==str(strippedname.replace('_', ' ')).lower()
@@ -81,7 +81,7 @@ def getRatId(bot, ratname, platform=None):
             if len(retlist) == 0:
                 ratnam = tempnam
                 ratplat = tempplat
-                print("======\n setting ID to zero... because FIRETRUCK this")
+                # print("======\n setting ID to zero... because FIRETRUCK this")
                 id = 0
             else:
                 id = retlist[0]['id']
@@ -95,7 +95,7 @@ def getRatId(bot, ratname, platform=None):
             id = None
             ratnam = None
             if len(data) == 0:
-                print('data length 0')
+                # print('data length 0')
                 raise Exception
             for user in data:
                 for ratobject in user['rats']:

--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -36,10 +36,10 @@ def getRatId(bot, ratname, platform=None):
         element = savedratids.get(ratname)
         strippedname = removeTags(ratname)
         if (platform is None) and ((str(element['name']).lower()==str(ratname).lower()) or str(element['name']).lower()==str(strippedname).lower() or str(element['name']).lower()==str(strippedname.replace('_',' ')).lower()):
-            # print('platform was None and '+ratname+' was in keys and the name matched. returning '+str(element))
+            print('platform was None and '+ratname+' was in keys and the name matched. returning '+str(element))
             return element
         elif (platform == element['platform']) and ((str(element['name']).lower()==str(ratname).lower()) or str(element['name']).lower()==str(strippedname).lower() or str(element['name']).lower()==str(strippedname.replace('_',' ')).lower()):
-            # print('platform was on the gotten name and names matched. Returning '+str(element))
+            print('platform was on the gotten name and names matched. Returning '+str(element))
             return element
 
 
@@ -48,8 +48,8 @@ def getRatId(bot, ratname, platform=None):
         # print('looking for name '+ratname)
         # print('uri: '+str(uri))
         result = callapi(bot=bot, method='GET', uri=uri)
-        # print(result)
         data = result['data']['attributes']['rows']
+        # print(result)
         # print(data)
         returnlist = []
         if platform is None:
@@ -60,16 +60,28 @@ def getRatId(bot, ratname, platform=None):
             retlist = []
             tempnam = 'unknown name'
             tempplat = 'unknown platform'
+            nicknames = firstmatch['nicknames']
+            tempAlias = []
+            for alias in nicknames:
+                tempAlias.append(alias.lower())
+            # print("looping over firstmatch['rats']...")
 
             for ratobject in firstmatch['rats']:
                 id = ratobject['id']
                 tempnam = ratobject['name']
                 tempplat = ratobject['platform']
-                if (str(tempnam).lower()==str(ratname).lower() or str(tempnam).lower()==str(strippedname).lower() or str(tempnam).lower()==str(strippedname.replace('_', ' ')).lower()):
-                    retlist.append({'id': id, 'name':tempnam , 'platform':tempplat})
+
+                print("tempnam = {}\ntempplat={}\n--------\nid={}".format(tempnam,tempplat, id))
+                if (str(tempnam).lower()==str(ratname).lower()
+                    or str(tempnam).lower()==str(strippedname).lower()
+                    or str(tempnam).lower()==str(strippedname.replace('_', ' ')).lower()
+                    or strippedname.lower() in tempAlias):
+                        # print("appending rat!")
+                        retlist.append({'id': id, 'name':tempnam , 'platform':tempplat})
             if len(retlist) == 0:
                 ratnam = tempnam
                 ratplat = tempplat
+                print("======\n setting ID to zero... because FIRETRUCK this")
                 id = 0
             else:
                 id = retlist[0]['id']
@@ -83,7 +95,7 @@ def getRatId(bot, ratname, platform=None):
             id = None
             ratnam = None
             if len(data) == 0:
-                # print('data length 0')
+                print('data length 0')
                 raise Exception
             for user in data:
                 for ratobject in user['rats']:
@@ -108,8 +120,10 @@ def getRatId(bot, ratname, platform=None):
             savedratnames.update({id: {'name': ratnam, 'platform': ret['platform'], 'id':ret['id']}})
         # print("returning " + str(ret))
         return ret
-    except:
-            # print('Calling fallback on ratID search as no rat with registered nickname '+strippedname+' or '+ratname+' was found.')
+    except Exception as ex:
+            # raise ex  # burn baby burn
+            print('Calling fallback on ratID search as no rat with registered nickname '+strippedname+' or '+ratname+' was found.')
+
             return idFallback(bot, ratname, platform=platform)
 
 
@@ -127,7 +141,9 @@ def idFallback(bot, ratname, platform=None):
 
     """
     strippedname = removeTags(ratname)
-    print('[NamesAPI] Had to call idFallback for '+str(ratname))
+    # print('[NamesAPI] Had to call idFallback for '+str(ratname))
+    print('[NamesAPI] had to call idFallback for {ratname} (strippedName = {strippedName}'.format(
+            ratname=ratname, strippedName=strippedname))
     try:
         uri = '/rats?name=' + strippedname + (('&platform='+platform) if platform is not None else '')
         result = callapi(bot=bot, method='GET', uri=uri)

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -1227,13 +1227,17 @@ def cmd_assign(bot, trigger, rescue, *rats):
 @ratlib.sopel.filter_output
 @parameterize('w', usage='<ratname>')
 @require_permission(Permissions.rat)
-def cmd_ratid(bot, trigger, rat):
+def cmd_ratid(bot, trigger, rat, platform=None):
     """
     Get a rats' id from the api
     required parameters: rat name
     aliases: ratid, id
     """
-    id = getRatId(bot=bot, ratname=rat)
+    if platform:
+        bot.say("searching for rat '{}' on {}".format(rat,platform))
+    else:
+        bot.say("searching for rat {}".format(rat))
+    id = getRatId(bot=bot, ratname=rat, platform=platform)
     bot.say('Rat id for ' + str(id['name']) + ' is ' + str(id['id']))
 
 


### PR DESCRIPTION
mitigated instances where rats stripped IRC names != ratnames caused getRatID to fail and return `0`
 - this should fix instances where rats use a name different from their registered rat's names causes names.getRatID() to fail
Also added ability to search ratID by platform. E.G. `!ratid rat pc`
 - no error checking to ensure valid platform.