### PR TITLE
FIltered List Attempt #2

### DIFF
--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -990,7 +990,7 @@ def cmd_list(bot, trigger, *remainder):
         if expand:
             # list all rescues and replace rescues with IGNOREME if only unassigned rescues should be shown and the
             # rescues have more than 0 assigned rats
-            # will also replace every rescue that shouldnt not be shown based on the supplied platform
+            # will also replace every rescue that should not be shown based on the supplied platform
             # FIXME: should be done easier to read, but it should work. I wanted to stick to the old way it was
             # implemented.
             templist = \

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -915,9 +915,10 @@ def cmd_list(bot, trigger, *remainder):
     params = ['']
     tmp = ''
     for x in remainder:
-        if x in ['@', 'i', 'r', 'u']:
+        if ['@', 'i', 'r', 'u'] in list(x):
             params[0] = '-'
             params.append(x)
+        elif '-' in list(x): None #ignore '-'
         else:
             plats.append(x)
 
@@ -936,7 +937,7 @@ def cmd_list(bot, trigger, *remainder):
     plats = tmpStr.split(' ')
     
     for x in plats:
-        if x not in ['pc', 'ps', 'xb']:
+        if x not in ['pc', 'ps', 'xb', '',  '-']:
             raise UsageError()
     
     showpc = 'pc' in plats

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -972,8 +972,8 @@ def cmd_list(bot, trigger, *remainder):
             continue
         num = len(cases)
         s = 's' if num != 1 else ''
-        t = []
-        t.append("{num} {name} case{s}".format(num=num, name=name, s=s))
+        tmpOutput = []
+        tmpOutput.append("{num} {name} case{s}".format(num=num, name=name, s=s))
         if expand:
             # list all rescues and replace rescues with IGNOREME if only unassigned rescues should be shown and the
             # rescues have more than 0 assigned rats
@@ -989,16 +989,16 @@ def cmd_list(bot, trigger, *remainder):
             for formatted in templist:
                 if formatted != 'IGNOREME':
                     formatlist.append(formatted)
-                    t.append(formatted)
+                    tmpOutput.append(formatted)
             num = len(formatlist) if len(formatlist) != 0 else "No"
             s = 's' if num != 1 else ''
-            t[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)
+            tmpOutput[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)
         else:
             tempcount = 0
-            tempcount +=  (1 if (showAllPlats or showPlats.__contains__(rescue.platform)) else 0 for rescue in cases)
+            tempcount +=  (1 if (showAllPlats or rescue.platform in showPlats) else 0 for rescue in cases)
             num = tempcount if tempcount != 0 else "No"
             s = 's' if num != 1 else ''
-            t[0] = t[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)
+            tmpOutput[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)
         output.append(t)
     for part in output:
         totalCount = 0

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -940,9 +940,9 @@ def cmd_list(bot, trigger, *remainder):
     showAllPlats = True if not (showpc or showps or showxb) else False
 
     showPlats = []
-    showPlats.append("pc") if showpc else None
-    showPlats.append("ps") if showps else None
-    showPlats.append("xb") if showxb else None
+    if showpc: showPlats.append("pc")
+    if showps: showPlats.append("ps")
+    if showxb: showPlats.append("xb")
 
     if not params or params[0] != '-':
         params = '-'
@@ -999,7 +999,7 @@ def cmd_list(bot, trigger, *remainder):
             num = tempcount if tempcount != 0 else "No"
             s = 's' if num != 1 else ''
             tmpOutput[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)
-        output.append(t)
+        output.append(tmpOutput)
     for part in output:
         totalCount = 0
         length = len(part)

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -983,7 +983,7 @@ def cmd_list(bot, trigger, *remainder):
             templist = \
                 (format_rescue(bot, rescue, attr, showassigned, showids, hideboardindexes=False, showmarkedfordeletionreason=False)
                  if (not unassigned or len(rescue.rats) == 0 and len(rescue.unidentifiedRats) == 0)
-                    and (showAllPlats or showPlats.__contains__(rescue.platform)) else 'IGNOREME'
+                    and (showAllPlats or rescue.platform in showPlats) else 'IGNOREME'
                  for rescue in cases)
             formatlist = []
             for formatted in templist:

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -914,13 +914,20 @@ def cmd_list(bot, trigger, *remainder):
     plats = []
     params = ['']
     tmp = ''
-    for x in remainder:
-        if ['@', 'i', 'r', 'u'] in list(x):
-            params[0] = '-'
-            params.append(x)
-        elif '-' in list(x): None #ignore '-'
-        else:
-            plats.append(x)
+
+    for y in remainder:
+        for x in list(y):
+            if x in ['@', 'i', 'r', 'u']:
+                params[0] = '-'
+                params.append(x)
+            elif x == '-': None #ignore '-'
+            else:
+                plats.append(x)
+
+    for i in range(1, len(list(params[0]))):
+        if list(params[0])[i] == '-':
+            list(params[0]).pop(i)
+            i -= 1
 
     tmpStr = ''
     for x in plats:
@@ -1001,7 +1008,9 @@ def cmd_list(bot, trigger, *remainder):
             tmpOutput[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)
         else:
             tempcount = 0
-            tempcount +=  (1 if (showAllPlats or rescue.platform in showPlats) else 0 for rescue in cases)
+            for rescue in cases:
+                if showAllPlats or rescue.platform in showPlats:
+                    tempcount += 1
             num = tempcount if tempcount != 0 else "No"
             s = 's' if num != 1 else ''
             tmpOutput[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -934,6 +934,11 @@ def cmd_list(bot, trigger, *remainder):
             offset += 1
     tmpStr = ''.join(tmp)
     plats = tmpStr.split(' ')
+    
+    for x in plats:
+        if x not in ['pc', 'ps', 'xb']:
+            raise UsageError()
+    
     showpc = 'pc' in plats
     showps = 'ps' in plats
     showxb = 'xb' in plats

--- a/sopel-modules/rat-board.py
+++ b/sopel-modules/rat-board.py
@@ -914,30 +914,37 @@ def cmd_list(bot, trigger, *remainder):
     plats = []
     params = ['']
     tmp = ''
-    for x in remainder:
-        if ['@', 'i', 'r', 'u'] in list(x):
-            params[0] = '-'
-            params.append(x)
-        elif '-' in list(x): None #ignore '-'
-        else:
-            plats.append(x)
+
+    for word in remainder:
+        for char in list(word):
+            if char in ['@', 'i', 'r', 'u']:
+                params[0] = '-'
+                params.append(char)
+            elif char == '-': None #ignore '-'
+            else:
+                plats.append(char)
+
+    for i in range(1, len(list(params[0]))):
+        if list(params[0])[i] == '-':
+            list(params[0]).pop(i)
+            i -= 1
 
     tmpStr = ''
-    for x in plats:
-        tmpStr += x
+    for element in plats:
+        tmpStr += element
 
     offset = 0
     tmp = list(tmpStr)
-    for x in range(0, len(tmpStr)):
-        if (x + offset) % 3 != 0 or x == 0: continue
-        if tmp[x + offset] != ' ':
-            tmp.insert(x + offset - 1, ' ')
+    for position in range(0, len(tmpStr)):
+        if (position + offset) % 3 != 0 or position == 0: continue
+        if tmp[position + offset] != ' ':
+            tmp.insert(position + offset - 1, ' ')
             offset += 1
     tmpStr = ''.join(tmp)
     plats = tmpStr.split(' ')
     
-    for x in plats:
-        if x not in ['pc', 'ps', 'xb', '',  '-']:
+    for plat in plats:
+        if plat not in ['pc', 'ps', 'xb', '',  '-']:
             raise UsageError()
     
     showpc = 'pc' in plats
@@ -1001,7 +1008,9 @@ def cmd_list(bot, trigger, *remainder):
             tmpOutput[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)
         else:
             tempcount = 0
-            tempcount +=  (1 if (showAllPlats or rescue.platform in showPlats) else 0 for rescue in cases)
+            for rescue in cases:
+                if showAllPlats or rescue.platform in showPlats:
+                    tempcount += 1
             num = tempcount if tempcount != 0 else "No"
             s = 's' if num != 1 else ''
             tmpOutput[0] = "{num} {name} case{s}".format(num=num, name=name, s=s)


### PR DESCRIPTION
!list is now filterable by supplying 'pc' 'xb' or 'ps' as parameters, these may be seperated by a space, but don't need to ('pcxb' is a valid parameter). If a case has no platform assigned, it will only show up if called with no filters. If you filter by all three platforms, platform-less cases will not show up.
