### PR TITLE
Fix annoying (and stuff-breaking) typo in RescueBoard.find

### DIFF
--- a/sopel_modules/rat_board.py
+++ b/sopel_modules/rat_board.py
@@ -286,7 +286,7 @@ class RescueBoard:
             return FindRescueResult(None, None)
 
         if search[0] == '@':
-            rescue = self.indexes['id'].get(search[1:], None),
+            rescue = self.indexes['id'].get(search[1:], None)
             return FindRescueResult(rescue, False if rescue else None)
 
         # print('Indexes: '+str(self.indexes))


### PR DESCRIPTION
Fix a typo in `RescueBoard.find` that caused it to return
`FindRescueResult(rescue=(the_rescue_were_looking_for, ), created=False)` instead of
`FindRescueResult(rescue=the_rescue_were_looking_for, created=False)`
when presented with a database id.
This causes the parameters `rRfF` to not work with ids (giving you a tuple instead of a Rescue object), producing the following ugly error:
```
<MHajoha> !clear @51d141a7-da74-4811-83a7-ba65be379ef9
<&DrillSqueak[BOT]> AttributeError: 'tuple' object has no attribute 'platform' (file "sopel-modules/rat-board.py", line 851, in func_clear)
```

Fixing this should allow commands with those parameters to correctly accept ids.