### PR TITLE
Feature/mecha 192

### DIFF
--- a/ratlib/api/props.py
+++ b/ratlib/api/props.py
@@ -112,6 +112,22 @@ class TrackedProperty:
         return self.remote_name in json
 
 
+class SystemNameProperty(TrackedProperty):
+    """
+    Property for System names.
+    """
+    def set(self, instance, value: str or None, dirty=True):
+        """
+        Set the value of the system name
+        :param instance: Instance of property
+        :param value: string value, will be cast to upper case
+        :param dirty:
+        :return:
+        """
+        # because the API expects upper case system names.
+        super().set(instance, value.upper() if value else None, dirty)
+
+
 class DateTimeProperty(TrackedProperty):
     UTC = datetime.timezone.utc
 

--- a/ratlib/api/props.py
+++ b/ratlib/api/props.py
@@ -116,14 +116,15 @@ class SystemNameProperty(TrackedProperty):
     """
     Property for System names.
     """
-    def set(self, instance, value: str or None, dirty=True):
+    def set(self, instance, value: str or None, dirty=True)->None:
         """
         Set the value of the system name
         :param instance: Instance of property
-        :param value: string value, will be cast to upper case
-        :param dirty:
-        :return:
+        :param value: string value, will be cast to upper case due to API 2.1 validation requirements
+        :param dirty: If True, adds this to the list of changed properties on the instance.
+        :return: None
         """
+        # As of Fuelrats API Version 2.1, system names are only valid if cast to all upper case.
         # because the API expects upper case system names.
         super().set(instance, value.upper() if value else None, dirty)
 

--- a/sopel_modules/rat_board.py
+++ b/sopel_modules/rat_board.py
@@ -1503,7 +1503,7 @@ def ratmama_parse(bot, trigger, db):
     # print('[RatBoard] triggered ratmama_parse')
     # print('[RatBoard] line: ' + line)
 
-    if Identifier(trigger.nick) in ('Ratmama[BOT]', 'Dewin'):
+    if Identifier(trigger.nick) in ('Ratmama[BOT]', 'Dewin','unknown'):
         match = _ratmama_regex.fullmatch(trigger.group())
         if not match:
             return

--- a/sopel_modules/rat_board.py
+++ b/sopel_modules/rat_board.py
@@ -263,7 +263,7 @@ class RescueBoard:
         searches.
         :return: A FindRescueResult tuple of (rescue, created), both of which will be None if no case was found.
 
-        If `int(search)` does not raise, `search` is treated as a boardindex.  This will never create a case.
+        If `int(search)` does not raise, `search` is treated as a `boardindex`.  This will never create a case.
 
         Otherwise, if `search` begins with `"@"`, it is treated as an ID from the API.  This will never create a case.
 
@@ -1549,8 +1549,6 @@ def ratmama_parse(bot, trigger, db):
                 "boardIndex": int(case.boardindex)
             })
 
-
-
         save_case_later(bot, case, forceFull=True)
         if result.created:
             # Add IRC formatting to fields, then substitute them into to output to the channel
@@ -1562,8 +1560,12 @@ def ratmama_parse(bot, trigger, db):
 
             if case.platform == 'xb':
                 fields["platform"] = color(fields["platform"], colors.GREEN)
+                fields["platform_signal"] = "XSIGNAL"
             elif case.platform == 'ps':
                 fields["platform"] = color("PS4", colors.LIGHT_BLUE)
+                fields["platform_signal"] = "PS_SIGNAL"
+            elif case.platform == 'pc':
+                fields["platform_signal"] = "PC_SIGNAL"
             fields["platform"] = bold(fields["platform"])
             fields["system"] = bold(fields["system"])
             fields["cmdr"] = bold(fields["cmdr"])
@@ -1575,7 +1577,7 @@ def ratmama_parse(bot, trigger, db):
             else:
                 fields["system"] += " (not in EDDB)"
 
-            bot.say((fmt + " (Case #{boardindex})").format(boardindex=case.boardindex, **fields))
+            bot.say((fmt + " (Case #{boardindex}) ({platform_signal})").format(boardindex=case.boardindex, **fields))
             if case.codeRed:
                 prepcrstring = getFact(bot, factname='prepcr', lang=fields["language_code"])
                 bot.say(

--- a/sopel_modules/rat_board.py
+++ b/sopel_modules/rat_board.py
@@ -1561,7 +1561,7 @@ def ratmama_parse(bot, trigger, db):
 
             if case.platform == 'xb':
                 fields["platform"] = color(fields["platform"], colors.GREEN)
-                fields["platform_signal"] = "XSIGNAL"
+                fields["platform_signal"] = "XB_SIGNAL"
             elif case.platform == 'ps':
                 fields["platform"] = color("PS4", colors.LIGHT_BLUE)
                 fields["platform_signal"] = "PS_SIGNAL"

--- a/sopel_modules/rat_board.py
+++ b/sopel_modules/rat_board.py
@@ -41,6 +41,7 @@ from sopel.module import require_privmsg, rate
 
 import ratlib.sopel
 from ratlib import timeutil
+from ratlib.api.props import SystemNameProperty
 from ratlib.autocorrect import correct
 from ratlib.starsystem import scan_for_systems
 from ratlib.api.props import *
@@ -330,7 +331,7 @@ class Rescue(TrackedBase):
     epic = TypeCoercedProperty(default=False, coerce=bool)
     codeRed = TypeCoercedProperty(default=False, coerce=bool)
     client = TrackedProperty(default='<unknown client>')
-    system = TrackedProperty(default=None)
+    system = SystemNameProperty(default=None)
     successful = TypeCoercedProperty(default=True, coerce=bool)
     title = TrackedProperty(default=None)
     firstLimpet = TrackedProperty(default='')
@@ -1503,7 +1504,7 @@ def ratmama_parse(bot, trigger, db):
     # print('[RatBoard] triggered ratmama_parse')
     # print('[RatBoard] line: ' + line)
 
-    if Identifier(trigger.nick) in ('Ratmama[BOT]', 'Dewin','unknown'):
+    if Identifier(trigger.nick) in ('Ratmama[BOT]', 'Dewin', 'unknown'):
         match = _ratmama_regex.fullmatch(trigger.group())
         if not match:
             return


### PR DESCRIPTION
This PR does two things: Firstly it makes a change to the `Rescue` object.

Due to API v2.1 requirements, all system names must be transmitted in upper case, but mecha as it stands on the `develop` branch does not cast system names to upper case therefore can cause 422 errors.

The first change is the `Rescue.System()` field now uses a `SystemNameProperty` object to store the system name in memory. This class simply casts the input string to uppercase, ensuring Mecha complies with API v2.1 requirements.

Second change: The `RATSIGNAL` phrase has been added to: it will now include platform-specific strings at the end of the message.
The added phrases are

- PC_SIGNAL
- PS_SIGNAL
- XB_SIGNAL

These will allow rats to set platform-specific pings while preserving the `ratsignal`.