### PR TITLE
Bugfix: ratid detection for users with multiple alts

### DIFF
--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -118,7 +118,7 @@ def getRatId(bot, ratname, platform=None):
             savedratids.update({ratname: ret})
             savedratnames.update({id: {'name': ratnam, 'platform': ret['platform'], 'id':ret['id']}})
         # print("returning " + str(ret))
-        return ret
+        return returnlist[0] if returnlist else ret
     except Exception as ex:
             # raise ex  # burn baby burn
             # print('Calling fallback on ratID search as no rat with registered nickname '+strippedname+' or '+ratname+' was found.')


### PR DESCRIPTION
An issue exists in mecha2's `names.py:getRatID` algorithm, where it can improperly detect a rat's alternate account in specific circumstances.

The issue stems from the algorithm iterating over the returned rats from the API, storing them in `ret` as temporary storage. If there are multiple rats on the filter platform, `ret` is overwritten with the latest entry, which may not be the rat object we are looking for. this `ret` rat object is then returned to the caller.

This algorithm does build a `retlist` object to track all the rats that match the specified filter, but subsequently does nothing with it. Based on some cursory testing, the API always returns the closest match to the searched nickname first, thus we should return the first object in `retlist`, should it exist.

This is a 1-liner PR that is tested to fix the reported issue by returning the first element in `retlist`, should it exist. Otherwise it defaults to the current behavior: returning `ret`.

