### PR TITLE
Push fix for alt name resolution to master

### DIFF
--- a/ratlib/api/names.py
+++ b/ratlib/api/names.py
@@ -118,7 +118,7 @@ def getRatId(bot, ratname, platform=None):
             savedratids.update({ratname: ret})
             savedratnames.update({id: {'name': ratnam, 'platform': ret['platform'], 'id':ret['id']}})
         # print("returning " + str(ret))
-        return ret
+        return returnlist[0] if returnlist else ret
     except Exception as ex:
             # raise ex  # burn baby burn
             # print('Calling fallback on ratID search as no rat with registered nickname '+strippedname+' or '+ratname+' was found.')


### PR DESCRIPTION
Can confirm #284 fixes the issue it sought out to correct.
production mecha behavior:
```
<unknown> !ratid Dr_Chives 
<MechaSqueak[BOT]> searching for rat Dr_Chives
<MechaSqueak[BOT]> Rat id for Dr. Chives is a3a6f256-0fef-4a63-a377-cc2176e5ef79
<unknown> !ratid Dr_Chives pc
<MechaSqueak[BOT]> searching for rat 'Dr_Chives' on pc
<MechaSqueak[BOT]> Rat id for Alchimeth is 36ce8172-185e-48cc-8281-9dcf8565c7f9
<unknown> there we go, ^ erroneous behavior
```

corrected drillsqueak behavior:
```
<unknown> !ratid Dr_Chives 
<Drillsqueak[BOT]> searching for rat Dr_Chives
<Drillsqueak[BOT]> Rat id for Dr. Chives is a3a6f256-0fef-4a63-a377-cc2176e5ef79
<unknown> !ratid Dr_Chives pc
<Drillsqueak[BOT]> searching for rat 'Dr_Chives' on pc
<Drillsqueak[BOT]> Rat id for Dr. Chives is a3a6f256-0fef-4a63-a377-cc2176e5ef79
<unknown> !ratid Alchimeth pc
<Drillsqueak[BOT]> searching for rat 'Alchimeth' on pc
<Drillsqueak[BOT]> Rat id for Alchimeth is 36ce8172-185e-48cc-8281-9dcf8565c7f9
```
