### PR TITLE
Landmark hacks

### DIFF
--- a/ratlib/exttypes.py
+++ b/ratlib/exttypes.py
@@ -46,8 +46,9 @@ class SQLPoint(types.UserDefinedType):
         def process(value):
             if value is None:
                 return value
-            if None in value:
-                raise ValueError('Value cannot contain None values')
+            # I have no idea why this is here, but it needs to shut the fuck up. -Abs
+            # if None in value:
+            #    raise ValueError('Value cannot contain None values')
             return ",".join(str(x) for x in value)
         return process
 

--- a/ratlib/exttypes.py
+++ b/ratlib/exttypes.py
@@ -49,7 +49,8 @@ class SQLPoint(types.UserDefinedType):
             # I have no idea why this is here, but it needs to shut the fuck up. -Abs
             # if None in value:
             #    raise ValueError('Value cannot contain None values')
-            return ",".join(str(x) for x in value)
+            #return ",".join(str(x) for x in value)
+            return value
         return process
 
     def result_processor(self, dialect, coltype):

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -422,6 +422,9 @@ def cmd_landmark(bot, trigger, db=None):
             if "error" in temp:
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
+            temp = temp[0] if temp else None
+            if not temp:
+                bot.reply(f"Empty result set from systems API.")
             starsystem.name = temp['name']
             if "coords" not in temp:
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -76,7 +76,7 @@ def sysapi_query(system, querytype):
             response = requests.get('https://system.api.fuelrats.com/landmark?name={}'.format(system))
             if response.status_code != 200:
                 return {"error": "System API did not respond with valid data."}
-            result = response.json()
+            result = response.json()[0]
         except Timeout:
             return {"error": "The request to Systems API timed out!"}
         return result

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -420,54 +420,8 @@ def cmd_landmark(bot, trigger, db=None):
     subcommand = parts.pop(0).lower() if parts else None
     system_name = parts.pop(0) if parts else None
 
-    def lookup_system(name, model=Starsystem):
-        return db.query(model).filter(model.name_lower == name.lower()).first()
-
-    def get_system_or_none(name):
-        if not system_name:
-            bot.reply("A starsystem name must be specified")
-            return None
-        starsystem = lookup_system(system_name)
-        if not starsystem:
-            temp = sysapi_query(system_name, "eq")
-            if "error" in temp:
-                bot.reply(f"Can't fetch data for {system_name}.")
-                return None
-            temp = temp[0] if temp else None
-            if not temp:
-                bot.reply(f"Empty result set from systems API.")
-            if "coords" not in temp['attributes']:
-                bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
-                return None
-            xz = "({x},{z})".format(**temp['attributes']['coords'])
-            name = temp['attributes']['name']
-            wordct = re.subn(r'\s+', ' ', name.strip())[1]
-            wordct += 1
-            starsystem = Starsystem(name=temp['attributes']['name'],
-                                    name_lower=temp['attributes']['name'].lower(),
-                                    first_word=name.split(" ", 1)[0],
-                                    xz=xz, y=temp['attributes']['coords']['y'],
-                                    word_ct=wordct, eddb_id=temp['id'])
-            tsp = StarsystemPrefix(name.split(" ", 1)[0], wordct)
-            tsp = db.merge(tsp)
-            db.commit()
-            starsystem = db.merge(starsystem)
-            db.commit()
-        return starsystem
-
     def subcommand_list(*unused_args, **unused_kwargs):
-        if not trigger.is_privmsg:
-            bot.reply("Messaging you the list of landmark systems.")
-
-        ix = 0
-        for ix, landmark in enumerate(db.query(Landmark).order_by(Landmark.name_lower), start=1):
-            if landmark.xz is None or landmark.y is None:
-                loc = "UNKNOWN LOCATION"
-            else:
-                loc = "({landmark.x:.2f}, {landmark.y:.2f}, {landmark.z:.2f})".format(landmark=landmark)
-
-            pm("Landmark #{ix} - {landmark.name} @ {loc}".format(ix=ix, landmark=landmark, loc=loc))
-        pm("{} landmark system(s) defined.".format(ix))
+        bot.reply("Landmark systems are no longer managed through Mecha.")
 
     def subcommand_near(*unused_args, **unused_kwargs):
         result = sysapi_query(f'{system_name}', 'landmark')
@@ -481,43 +435,17 @@ def cmd_landmark(bot, trigger, db=None):
     # @require_overseer(None)
     @require_permission(Permissions.overseer)
     def subcommand_add(*unused_args, **unused_kwargs):
-        starsystem = get_system_or_none(system_name)
-        if not starsystem:
-            return
-        landmark = Landmark(name=starsystem.name, name_lower=starsystem.name_lower, xz=starsystem.xz, y=starsystem.y)
-        landmark = db.merge(landmark)
-        persistent = object_state(landmark).persistent
-        db.commit()
-
-        if persistent:
-            bot.reply("System '{}' was already a landmark.  Updated to current coordinates.".format(starsystem.name))
-        else:
-            bot.reply("Added system '{}' as a landmark.".format(starsystem.name))
+        bot.reply("Landmarks are no longer managed through mecha. Contact Absolver.")
 
     # @require_overseer(None)
     @require_permission(Permissions.overseer, message=None)
     def subcommand_del(*unused_args, **unused_kwargs):
-        landmark = lookup_system(system_name, Landmark)
-        if landmark is None:
-            bot.reply("No such landmark '{}'".format(system_name))
-            return
-        db.delete(landmark)
-        db.commit()
-        bot.reply("Removed system '{}' from the list of landmarks.".format(landmark.name))
+        bot.reply("Landmarks are no longer managed through mecha. Contact Absolver.")
         pass
 
     @require_permission(Permissions.overseer, message=None)
     def subcommand_refresh(*unused_args, **unused_kwargs):
-        ct = (
-            db.query(Landmark)
-            .filter(Landmark.name_lower == Starsystem.name_lower)
-            .update({
-                Landmark.name: Starsystem.name,
-                Landmark.xz: Starsystem.xz,
-                Landmark.y: Starsystem.y
-            }, synchronize_session=False)
-        )
-        bot.reply("Synchronized {} landmark system(s).".format(ct))
+        bot.reply("Landmarks are no longer managed through mecha. Contact Absolver.")
 
     subcommands = {
         'list': subcommand_list,

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -71,6 +71,15 @@ def sysapi_query(system, querytype):
         except Timeout:
             return {"error": "The request to Systems API timed out!"}
         return result
+    if querytype == "landmark":
+        try:
+            response = requests.get('https://system.api.fuelrats.com/landmark?name={}'.format(system))
+            if response.status_code != 200:
+                return {"error": "System API did not respond with valid data."}
+            result = response.json()
+        except Timeout:
+            return {"error": "The request to Systems API timed out!"}
+        return result
     else:
         try:
             response = requests.get(f'https://system.api.fuelrats.com/api/systems?filter[name:eq]={system}')
@@ -461,19 +470,12 @@ def cmd_landmark(bot, trigger, db=None):
         pm("{} landmark system(s) defined.".format(ix))
 
     def subcommand_near(*unused_args, **unused_kwargs):
-        starsystem = get_system_or_none(system_name)
-        if not starsystem:
-            return
-        landmark, distance = starsystem.nearest_landmark(db, True)
-        if not landmark:
-            bot.reply("Could not find a nearby landmark.  (Perhaps none are defined?)")
-            return
-        if not distance and starsystem.name_lower == landmark.name_lower:
-            bot.reply("{} is a landmark!".format(starsystem.name))
+        result = sysapi_query(f'{system_name}', 'landmark')
+        if not result:
             return
         bot.reply(
-            "{starsystem.name} is {distance:.2f} LY from {landmark.name}"
-            .format(starsystem=starsystem, landmark=landmark, distance=distance)
+            f"{result['meta']['name']} is {result['landmarks']['distance']:.2f} LY from "
+            f"{result['landmark']['name']}"
         )
 
     # @require_overseer(None)

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -432,8 +432,9 @@ def cmd_landmark(bot, trigger, db=None):
                 return None
             xz = "({x},{z})".format(**temp['attributes']['coords'])
             starsystem = Starsystem(name=temp['attributes']['name'],
+                                    name_lower=temp['attributes']['name'].lower(),
+                                    first_word=temp['attributes']['name'].split(" ", 1),
                                     xz=xz, y=temp['attributes']['coords']['y'])
-
         return starsystem
 
     def subcommand_list(*unused_args, **unused_kwargs):

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -427,14 +427,13 @@ def cmd_landmark(bot, trigger, db=None):
             print(f"Temp after: {temp} Attr: {temp['attributes']}")
             if not temp:
                 bot.reply(f"Empty result set from systems API.")
-            starsystem = Starsystem(name=temp['attributes']['name'])
             if "coords" not in temp['attributes']:
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None
-            starsystem.x = temp['attributes']['coords']['x']
-            starsystem.y = temp['attributes']['coords']['y']
-            starsystem.z = temp['attributes']['coords']['z']
-            starsystem.has_coordinates = True
+            xz = "({x},{z})".format(**temp['attributes']['coords'])
+            starsystem = Starsystem(name=temp['attributes']['name'],
+                                    xz=xz, y=temp['attributes']['coords']['y'])
+
         return starsystem
 
     def subcommand_list(*unused_args, **unused_kwargs):

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -422,6 +422,7 @@ def cmd_landmark(bot, trigger, db=None):
             if "error" in temp:
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
+            print(f"Temp: {temp}")
             temp = temp[0] if temp else None
             if not temp:
                 bot.reply(f"Empty result set from systems API.")

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -431,11 +431,12 @@ def cmd_landmark(bot, trigger, db=None):
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None
             xz = "({x},{z})".format(**temp['attributes']['coords'])
-            words = temp['attributes']['name'].split()
-            wordct = Counter(words)
+            name = temp['attributes']['name']
+            wordct = re.subn(r'\s+', ' ', name.strip())[1]
+            wordct += 1
             starsystem = Starsystem(name=temp['attributes']['name'],
                                     name_lower=temp['attributes']['name'].lower(),
-                                    first_word=temp['attributes']['name'].split(" ", 1),
+                                    first_word=name.split(" ", 1)[0],
                                     xz=xz, y=temp['attributes']['coords']['y'],
                                     word_ct=wordct, eddb_id=temp['id'])
             starsystem = db.merge(starsystem)

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -422,8 +422,7 @@ def cmd_landmark(bot, trigger, db=None):
             if "error" in temp:
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
-            temp = temp[0]
-            if "coords" not in temp.keys:
+            if "coords" not in temp:
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None
             starsystem.name = temp['name']

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -427,7 +427,7 @@ def cmd_landmark(bot, trigger, db=None):
             print(f"Temp after: {temp} Attr: {temp['attributes']}")
             if not temp:
                 bot.reply(f"Empty result set from systems API.")
-            starsystem.name = temp['attributes']['name']
+            starsystem = Starsystem(name=temp['attributes']['name'])
             if "coords" not in temp['attributes']:
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -423,7 +423,7 @@ def cmd_landmark(bot, trigger, db=None):
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
             print(f"Temp: {temp}")
-            temp = temp[0] if temp else None
+            temp = temp[0]['attributes'] if temp else None
             if not temp:
                 bot.reply(f"Empty result set from systems API.")
             starsystem.name = temp['name']

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -418,7 +418,7 @@ def cmd_landmark(bot, trigger, db=None):
             return None
         starsystem = lookup_system(system_name)
         if not starsystem:
-            temp = sysapi_query("system_name", "eq")
+            temp = sysapi_query(system_name, "eq")
             if "error" in temp:
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -422,9 +422,7 @@ def cmd_landmark(bot, trigger, db=None):
             if "error" in temp:
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
-            print(f"Temp: {temp}")
             temp = temp[0] if temp else None
-            print(f"Temp after: {temp} Attr: {temp['attributes']}")
             if not temp:
                 bot.reply(f"Empty result set from systems API.")
             if "coords" not in temp['attributes']:
@@ -435,6 +433,8 @@ def cmd_landmark(bot, trigger, db=None):
                                     name_lower=temp['attributes']['name'].lower(),
                                     first_word=temp['attributes']['name'].split(" ", 1),
                                     xz=xz, y=temp['attributes']['coords']['y'])
+            starsystem = db.merge(starsystem)
+            db.commit()
         return starsystem
 
     def subcommand_list(*unused_args, **unused_kwargs):

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -109,7 +109,7 @@ def search(bot, trigger, db=None):
         system_name += " (autocorrected)"
 
     result = sysapi_query(system, "search")
-    if "error" in result.keys:
+    if "error" in result:
         return bot.say(f"An error occured while accessing systems API: {result['error']}")
     if result:
         return bot.say("Nearest matches for {system_name} are: {matches}".format(
@@ -419,9 +419,10 @@ def cmd_landmark(bot, trigger, db=None):
         starsystem = lookup_system(system_name)
         if not starsystem:
             temp = sysapi_query("system_name", "eq")
-            if "error" in temp.keys:
+            if "error" in temp:
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
+            temp = temp[0]
             if "coords" not in temp.keys:
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -21,6 +21,8 @@ import os
 import datetime
 import threading
 import functools
+from collections import Counter
+
 import requests
 from requests.exceptions import Timeout
 
@@ -429,12 +431,13 @@ def cmd_landmark(bot, trigger, db=None):
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None
             xz = "({x},{z})".format(**temp['attributes']['coords'])
-            words = re.subn(r'\s+', ' ', temp['attributes']['name'].strip())
+            words = temp['attributes']['name'].split()
+            wordct = Counter(words)
             starsystem = Starsystem(name=temp['attributes']['name'],
                                     name_lower=temp['attributes']['name'].lower(),
                                     first_word=temp['attributes']['name'].split(" ", 1),
                                     xz=xz, y=temp['attributes']['coords']['y'],
-                                    word_ct=words)
+                                    word_ct=wordct, eddb_id=temp['id'])
             starsystem = db.merge(starsystem)
             db.commit()
         return starsystem

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -429,10 +429,12 @@ def cmd_landmark(bot, trigger, db=None):
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None
             xz = "({x},{z})".format(**temp['attributes']['coords'])
+            words = re.subn(r'\s+', ' ', temp['attributes']['name'].strip())
             starsystem = Starsystem(name=temp['attributes']['name'],
                                     name_lower=temp['attributes']['name'].lower(),
                                     first_word=temp['attributes']['name'].split(" ", 1),
-                                    xz=xz, y=temp['attributes']['coords']['y'])
+                                    xz=xz, y=temp['attributes']['coords']['y'],
+                                    word_ct=words)
             starsystem = db.merge(starsystem)
             db.commit()
         return starsystem

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -422,10 +422,10 @@ def cmd_landmark(bot, trigger, db=None):
             if "error" in temp:
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
+            starsystem.name = temp['name']
             if "coords" not in temp:
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None
-            starsystem.name = temp['name']
             starsystem.x = temp['coords']['x']
             starsystem.y = temp['coords']['y']
             starsystem.z = temp['coords']['z']

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -76,7 +76,7 @@ def sysapi_query(system, querytype):
             response = requests.get('https://system.api.fuelrats.com/landmark?name={}'.format(system))
             if response.status_code != 200:
                 return {"error": "System API did not respond with valid data."}
-            result = response.json()[0]
+            result = response.json()
         except Timeout:
             return {"error": "The request to Systems API timed out!"}
         return result
@@ -474,8 +474,8 @@ def cmd_landmark(bot, trigger, db=None):
         if not result:
             return
         bot.reply(
-            f"{result['meta']['name']} is {result['landmarks']['distance']:.2f} LY from "
-            f"{result['landmark']['name']}"
+            f"{result['meta']['name']} is {result['landmarks'][0]['distance']:.2f} LY from "
+            f"{result['landmarks'][0]['name']}"
         )
 
     # @require_overseer(None)

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -427,13 +427,13 @@ def cmd_landmark(bot, trigger, db=None):
             print(f"Temp after: {temp} Attr: {temp['attributes']}")
             if not temp:
                 bot.reply(f"Empty result set from systems API.")
-            starsystem.name = temp['name']
-            if "coords" not in temp:
+            starsystem.name = temp['attributes']['name']
+            if "coords" not in temp['attributes']:
                 bot.reply("Starsystem '{}' has unknown coordinates.".format(starsystem.name))
                 return None
-            starsystem.x = temp['coords']['x']
-            starsystem.y = temp['coords']['y']
-            starsystem.z = temp['coords']['z']
+            starsystem.x = temp['attributes']['coords']['x']
+            starsystem.y = temp['attributes']['coords']['y']
+            starsystem.z = temp['attributes']['coords']['z']
             starsystem.has_coordinates = True
         return starsystem
 

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -439,6 +439,9 @@ def cmd_landmark(bot, trigger, db=None):
                                     first_word=name.split(" ", 1)[0],
                                     xz=xz, y=temp['attributes']['coords']['y'],
                                     word_ct=wordct, eddb_id=temp['id'])
+            tsp = StarsystemPrefix(name.split(" ", 1)[0], wordct)
+            tsp = db.merge(tsp)
+            db.commit()
             starsystem = db.merge(starsystem)
             db.commit()
         return starsystem

--- a/sopel_modules/rat_search.py
+++ b/sopel_modules/rat_search.py
@@ -423,7 +423,8 @@ def cmd_landmark(bot, trigger, db=None):
                 bot.reply(f"Can't fetch data for {system_name}.")
                 return None
             print(f"Temp: {temp}")
-            temp = temp[0]['attributes'] if temp else None
+            temp = temp[0] if temp else None
+            print(f"Temp after: {temp} Attr: {temp['attributes']}")
             if not temp:
                 bot.reply(f"Empty result set from systems API.")
             starsystem.name = temp['name']


### PR DESCRIPTION
Reroutes !landmark near to use systems API. Disables the old management commands, new landmark systems have to be added through the systems API. (I may add management calls later to allow OV+ to manipulate it, but we seldom need to add or remove landmarks in the first place...)